### PR TITLE
feat: support prototype scope in BeanFactory

### DIFF
--- a/summer-beans/src/main/java/com/dianpoint/summer/beans/factory/config/BeanDefinition.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/beans/factory/config/BeanDefinition.java
@@ -12,8 +12,8 @@ import com.dianpoint.summer.beans.PropertyValues;
  * @date: 2023/3/17 11:51
  */
 public class BeanDefinition {
-    String SCOPE_SINGLETON = "singleton";
-    String SCOPE_PROTOTYPE = "prototype";
+    public static final String SCOPE_SINGLETON = "singleton";
+    public static final String SCOPE_PROTOTYPE = "prototype";
 
     private boolean lazyInit = true;
     private String[] dependsOn;
@@ -29,6 +29,8 @@ public class BeanDefinition {
     public BeanDefinition(String id, String className) {
         this.id = id;
         this.className = className;
+        this.constructorArgumentValues = new ConstructorArgumentValues();
+        this.propertyValues = new PropertyValues();
     }
 
     public boolean isLazyInit() {

--- a/summer-beans/src/main/java/com/dianpoint/summer/beans/factory/support/AbstractBeanFactory.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/beans/factory/support/AbstractBeanFactory.java
@@ -32,13 +32,13 @@ public abstract class AbstractBeanFactory extends DefaultSingletonBeanRegistry
 
     public AbstractBeanFactory() {}
 
-    /**
-     * 对于refresh方法进行刷新Bean处理。本质上是对于所有的beanName分别进行getBean处理
-     */
     public void refresh() {
         for (String beanName : beanDefinitionNames) {
             try {
-                getBean(beanName);
+                BeanDefinition bd = beanDefinitions.get(beanName);
+                if (!bd.isPrototype()) {
+                    getBean(beanName);
+                }
             } catch (BeansException e) {
                 e.printStackTrace();
             }
@@ -47,31 +47,39 @@ public abstract class AbstractBeanFactory extends DefaultSingletonBeanRegistry
 
     @Override
     public Object getBean(String beanName) throws BeansException {
-        Object singleton = this.getSingleton(beanName);
-        if (singleton == null) {
-            // 当前没有单例对象时 进行获取一个早期的bean定义
-            singleton = this.earlySingletonObjects.get(beanName);
-            if (singleton == null) {
-                BeanDefinition beanDefinition = beanDefinitions.get(beanName);
-                // 根据beanDefinition创建得到的单例实例化对象
-                singleton = createBean(beanDefinition);
-                this.registerBean(beanName, singleton);
-                // beanPostProcessorBeforeInitialization执行
-                applyBeanPostProcessorsBeforeInitialization(singleton, beanName);
+        BeanDefinition beanDefinition = beanDefinitions.get(beanName);
 
-                // initMethod
-                if (beanDefinition.getInitMethodName() != null) {
-                    invokeInitMethod(beanDefinition, singleton);
+        if (beanDefinition.isSingleton()) {
+            Object singleton = this.getSingleton(beanName);
+            if (singleton == null) {
+                singleton = this.earlySingletonObjects.get(beanName);
+                if (singleton == null) {
+                    singleton = createBean(beanDefinition);
+                    this.registerBean(beanName, singleton);
+                    applyBeanPostProcessorsBeforeInitialization(singleton, beanName);
+
+                    if (beanDefinition.getInitMethodName() != null) {
+                        invokeInitMethod(beanDefinition, singleton);
+                    }
+                    applyBeanPostProcessorsAfterInitialization(singleton, beanName);
                 }
-                // postProcessAfterInitialization
-                applyBeanPostProcessorsAfterInitialization(singleton, beanName);
             }
+            if (singleton == null) {
+                throw new BeansException("bean is null.");
+            }
+            return singleton;
         }
-        // 二次判断如果未实例化成功则异常处理
-        if (singleton == null) {
+
+        Object prototype = createBean(beanDefinition);
+        applyBeanPostProcessorsBeforeInitialization(prototype, beanName);
+        if (beanDefinition.getInitMethodName() != null) {
+            invokeInitMethod(beanDefinition, prototype);
+        }
+        applyBeanPostProcessorsAfterInitialization(prototype, beanName);
+        if (prototype == null) {
             throw new BeansException("bean is null.");
         }
-        return singleton;
+        return prototype;
     }
 
     private void invokeInitMethod(BeanDefinition beanDefinition, Object singleton) {

--- a/summer-beans/src/test/java/com/dianpoint/summer/test/beans/PrototypeScopeTest.java
+++ b/summer-beans/src/test/java/com/dianpoint/summer/test/beans/PrototypeScopeTest.java
@@ -1,0 +1,132 @@
+package com.dianpoint.summer.test.beans;
+
+import com.dianpoint.summer.beans.BeansException;
+import com.dianpoint.summer.beans.factory.config.BeanDefinition;
+import com.dianpoint.summer.beans.factory.support.DefaultListableBeanFactory;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PrototypeScopeTest {
+
+    public static class TestBean {
+    }
+
+    public static class CounterBean {
+        private static int counter = 0;
+        private final int id;
+
+        public CounterBean() {
+            counter++;
+            id = counter;
+        }
+
+        public int getId() {
+            return id;
+        }
+    }
+
+    @Test
+    public void testPrototypeBeanCreatesNewInstance() throws BeansException {
+        DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+        BeanDefinition bd = new BeanDefinition("protoBean", CounterBean.class.getName());
+        bd.setScope(BeanDefinition.SCOPE_PROTOTYPE);
+        factory.registerBeanDefinition("protoBean", bd);
+
+        CounterBean bean1 = (CounterBean) factory.getBean("protoBean");
+        CounterBean bean2 = (CounterBean) factory.getBean("protoBean");
+
+        assertThat(bean1).isNotNull();
+        assertThat(bean2).isNotNull();
+        assertThat(bean1).isNotSameAs(bean2);
+        assertThat(bean1.getId()).isNotEqualTo(bean2.getId());
+    }
+
+    @Test
+    public void testPrototypeBeanNotInSingletonRegistry() throws BeansException {
+        DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+        BeanDefinition bd = new BeanDefinition("protoBean", TestBean.class.getName());
+        bd.setScope(BeanDefinition.SCOPE_PROTOTYPE);
+        factory.registerBeanDefinition("protoBean", bd);
+
+        factory.getBean("protoBean");
+
+        assertThat(factory.containsSingleton("protoBean")).isFalse();
+    }
+
+    @Test
+    public void testIsPrototypeReturnsTrue() {
+        DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+        BeanDefinition bd = new BeanDefinition("protoBean", TestBean.class.getName());
+        bd.setScope(BeanDefinition.SCOPE_PROTOTYPE);
+        factory.registerBeanDefinition("protoBean", bd);
+
+        assertThat(factory.isPrototype("protoBean")).isTrue();
+    }
+
+    @Test
+    public void testIsSingletonReturnsFalse() {
+        DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+        BeanDefinition bd = new BeanDefinition("protoBean", TestBean.class.getName());
+        bd.setScope(BeanDefinition.SCOPE_PROTOTYPE);
+        factory.registerBeanDefinition("protoBean", bd);
+
+        assertThat(factory.isSingleton("protoBean")).isFalse();
+    }
+
+    @Test
+    public void testRefreshSkipsPrototypeBean() {
+        DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+        BeanDefinition protoBd = new BeanDefinition("protoBean", TestBean.class.getName());
+        protoBd.setScope(BeanDefinition.SCOPE_PROTOTYPE);
+        protoBd.setLazyInit(false);
+        factory.registerBeanDefinition("protoBean", protoBd);
+
+        BeanDefinition singBd = new BeanDefinition("singBean", TestBean.class.getName());
+        singBd.setLazyInit(false);
+        factory.registerBeanDefinition("singBean", singBd);
+
+        assertThat(factory.containsSingleton("singBean")).isTrue();
+        assertThat(factory.containsSingleton("protoBean")).isFalse();
+    }
+
+    @Test
+    public void testSingletonBeanStillWorks() throws BeansException {
+        DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+        BeanDefinition bd = new BeanDefinition("singBean", TestBean.class.getName());
+        factory.registerBeanDefinition("singBean", bd);
+
+        TestBean bean1 = (TestBean) factory.getBean("singBean");
+        TestBean bean2 = (TestBean) factory.getBean("singBean");
+
+        assertThat(bean1).isSameAs(bean2);
+    }
+
+    @Test
+    public void testPrototypeBeanWithInitMethod() throws BeansException {
+        DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+        BeanDefinition bd = new BeanDefinition("protoBean", InitMethodBean.class.getName());
+        bd.setScope(BeanDefinition.SCOPE_PROTOTYPE);
+        bd.setInitMethodName("init");
+        factory.registerBeanDefinition("protoBean", bd);
+
+        InitMethodBean bean1 = (InitMethodBean) factory.getBean("protoBean");
+        InitMethodBean bean2 = (InitMethodBean) factory.getBean("protoBean");
+
+        assertThat(bean1.isInitialized()).isTrue();
+        assertThat(bean2.isInitialized()).isTrue();
+        assertThat(bean1).isNotSameAs(bean2);
+    }
+
+    public static class InitMethodBean {
+        private boolean initialized = false;
+
+        public void init() {
+            initialized = true;
+        }
+
+        public boolean isInitialized() {
+            return initialized;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implement prototype scope support in the IoC container.

### Changes
- **`AbstractBeanFactory.getBean()`**: Add prototype branch — creates a fresh instance each time without storing in the singleton registry
- **`AbstractBeanFactory.refresh()`**: Skip prototype beans during eager initialization (only pre-instantiate singletons)
- **`BeanDefinition`**: Make `SCOPE_SINGLETON` and `SCOPE_PROTOTYPE` public static final constants; initialize `constructorArgumentValues` and `propertyValues` in constructor to prevent NPE
- **`PrototypeScopeTest`**: 7 unit tests covering prototype creation, singleton registry exclusion, refresh behavior, and init-method support

### Verification
```
mvn test -pl summer-beans  # 100 tests pass, 0 failures
mvn test                   # all modules pass
```