### PR TITLE
feat: invoke BeanFactoryPostProcessors during context refresh

### DIFF
--- a/summer-beans/src/main/java/com/dianpoint/summer/context/ClassPathXmlApplicationContext.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/context/ClassPathXmlApplicationContext.java
@@ -21,8 +21,6 @@ import com.dianpoint.summer.core.Resource;
 public class ClassPathXmlApplicationContext extends AbstractApplicationContext {
     private DefaultListableBeanFactory beanFactory;
 
-    private List<BeanFactoryPostProcessor> beanFactoryPostProcessors = new ArrayList<>();
-
     private InitDestroyAnnotationBeanPostProcessor initDestroyBeanPostProcessor;
 
     public ClassPathXmlApplicationContext(String fileName) {
@@ -114,7 +112,13 @@ public class ClassPathXmlApplicationContext extends AbstractApplicationContext {
 
     @Override
     public void postProcessBeanFactory(ConfigurableListableBeanFactory configurableListableBeanFactory) {
-
+        for (BeanFactoryPostProcessor processor : this.getBeanFactoryPostProcessors()) {
+            try {
+                processor.postProcessBeanFactory(configurableListableBeanFactory);
+            } catch (BeansException e) {
+                e.printStackTrace();
+            }
+        }
     }
 
     @Override

--- a/summer-beans/src/test/java/com/dianpoint/summer/test/beans/BeanFactoryPostProcessorTest.java
+++ b/summer-beans/src/test/java/com/dianpoint/summer/test/beans/BeanFactoryPostProcessorTest.java
@@ -1,0 +1,65 @@
+package com.dianpoint.summer.test.beans;
+
+import com.dianpoint.summer.beans.BeansException;
+import com.dianpoint.summer.beans.factory.BeanFactory;
+import com.dianpoint.summer.beans.factory.config.BeanFactoryPostProcessor;
+import com.dianpoint.summer.beans.factory.config.ConfigurableListableBeanFactory;
+import com.dianpoint.summer.context.ClassPathXmlApplicationContext;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeanFactoryPostProcessorTest {
+
+    @Test
+    public void testBeanFactoryPostProcessorIsInvoked() throws BeansException {
+        AtomicBoolean invoked = new AtomicBoolean(false);
+        ClassPathXmlApplicationContext ctx = new ClassPathXmlApplicationContext("xml/beanAutowire.xml", false);
+        ctx.addBeanFactoryPostProcessor(new BeanFactoryPostProcessor() {
+            @Override
+            public void postProcessBeanFactory(BeanFactory beanFactory) throws BeansException {
+                invoked.set(true);
+            }
+        });
+        ctx.refresh();
+        assertThat(invoked.get()).isTrue();
+    }
+
+    @Test
+    public void testBeanFactoryPostProcessorAccessesFactory() throws BeansException {
+        ClassPathXmlApplicationContext ctx = new ClassPathXmlApplicationContext("xml/beanAutowire.xml", false);
+        ctx.addBeanFactoryPostProcessor(new BeanFactoryPostProcessor() {
+            @Override
+            public void postProcessBeanFactory(BeanFactory beanFactory) throws BeansException {
+                ConfigurableListableBeanFactory clbf = (ConfigurableListableBeanFactory) beanFactory;
+                assertThat(clbf.getBeanDefinitionCount()).isGreaterThan(0);
+            }
+        });
+        ctx.refresh();
+        assertThat(ctx.getBeanDefinitionCount()).isGreaterThan(0);
+    }
+
+    @Test
+    public void testMultipleBeanFactoryPostProcessors() throws BeansException {
+        AtomicBoolean firstInvoked = new AtomicBoolean(false);
+        AtomicBoolean secondInvoked = new AtomicBoolean(false);
+        ClassPathXmlApplicationContext ctx = new ClassPathXmlApplicationContext("xml/beanAutowire.xml", false);
+        ctx.addBeanFactoryPostProcessor(new BeanFactoryPostProcessor() {
+            @Override
+            public void postProcessBeanFactory(BeanFactory beanFactory) throws BeansException {
+                firstInvoked.set(true);
+            }
+        });
+        ctx.addBeanFactoryPostProcessor(new BeanFactoryPostProcessor() {
+            @Override
+            public void postProcessBeanFactory(BeanFactory beanFactory) throws BeansException {
+                secondInvoked.set(true);
+            }
+        });
+        ctx.refresh();
+        assertThat(firstInvoked.get()).isTrue();
+        assertThat(secondInvoked.get()).isTrue();
+    }
+}


### PR DESCRIPTION
## Summary

BeanFactoryPostProcessor interface was defined but never invoked. This PR wires it into the refresh() lifecycle.

### Changes
- Remove shadow `beanFactoryPostProcessors` field in `ClassPathXmlApplicationContext` (was dead code)
- Implement `postProcessBeanFactory()` to iterate and invoke all registered processors
- Add `BeanFactoryPostProcessorTest` with 3 tests

### Verification
```
mvn test -pl summer-beans  # all tests pass
```