### PR TITLE
feat: add @Value annotation with property placeholder resolution

### DIFF
--- a/summer-beans/src/main/java/com/dianpoint/summer/beans/factory/annotation/Value.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/beans/factory/annotation/Value.java
@@ -1,0 +1,12 @@
+package com.dianpoint.summer.beans.factory.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Value {
+    String value();
+}

--- a/summer-beans/src/main/java/com/dianpoint/summer/beans/factory/annotation/ValueAnnotationBeanPostProcessor.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/beans/factory/annotation/ValueAnnotationBeanPostProcessor.java
@@ -1,0 +1,65 @@
+package com.dianpoint.summer.beans.factory.annotation;
+
+import com.dianpoint.summer.beans.BeansException;
+import com.dianpoint.summer.beans.factory.BeanFactory;
+import com.dianpoint.summer.beans.factory.config.BeanPostProcessor;
+import com.dianpoint.summer.core.env.PropertyResolver;
+import com.dianpoint.summer.core.env.SimplePropertyResolver;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ValueAnnotationBeanPostProcessor implements BeanPostProcessor {
+
+    private BeanFactory beanFactory;
+    private final SimplePropertyResolver propertyResolver = new SimplePropertyResolver(new ConcurrentHashMap<String, String>());
+
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        Class<?> clazz = bean.getClass();
+        Field[] fields = clazz.getDeclaredFields();
+        for (Field field : fields) {
+            Value valueAnnotation = field.getAnnotation(Value.class);
+            if (valueAnnotation != null) {
+                String expression = valueAnnotation.value();
+                String resolved = propertyResolver.resolvePlaceholders(expression);
+                if (resolved == null || resolved.equals(expression)) {
+                    resolved = expression;
+                }
+                field.setAccessible(true);
+                try {
+                    if (field.getType() == int.class || field.getType() == Integer.class) {
+                        field.set(bean, Integer.valueOf(resolved));
+                    } else if (field.getType() == long.class || field.getType() == Long.class) {
+                        field.set(bean, Long.valueOf(resolved));
+                    } else if (field.getType() == boolean.class || field.getType() == Boolean.class) {
+                        field.set(bean, Boolean.valueOf(resolved));
+                    } else {
+                        field.set(bean, resolved);
+                    }
+                } catch (IllegalAccessException e) {
+                    throw new BeansException("Failed to set @Value field " + field.getName());
+                }
+            }
+        }
+        return bean;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        return bean;
+    }
+
+    @Override
+    public void setBeanFactory(BeanFactory beanFactory) {
+        this.beanFactory = beanFactory;
+    }
+
+    public PropertyResolver getPropertyResolver() {
+        return propertyResolver;
+    }
+
+    public void addProperty(String key, String value) {
+        propertyResolver.addProperty(key, value);
+    }
+}

--- a/summer-beans/src/main/java/com/dianpoint/summer/core/env/SimplePropertyResolver.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/core/env/SimplePropertyResolver.java
@@ -1,0 +1,75 @@
+package com.dianpoint.summer.core.env;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class SimplePropertyResolver implements PropertyResolver {
+
+    private final Map<String, String> properties;
+
+    public SimplePropertyResolver() {
+        this.properties = new ConcurrentHashMap<>();
+    }
+
+    public SimplePropertyResolver(Map<String, String> properties) {
+        this.properties = new ConcurrentHashMap<>(properties);
+    }
+
+    public void addProperty(String key, String value) {
+        properties.put(key, value);
+    }
+
+    @Override
+    public boolean containsProperty(String key) {
+        return properties.containsKey(key);
+    }
+
+    @Override
+    public String getProperty(String key) {
+        return properties.get(key);
+    }
+
+    @Override
+    public String getProperty(String key, String defaultValue) {
+        String value = properties.get(key);
+        return value != null ? value : defaultValue;
+    }
+
+    public String resolvePlaceholders(String text) {
+        if (text == null) {
+            return null;
+        }
+        StringBuilder result = new StringBuilder();
+        int i = 0;
+        while (i < text.length()) {
+            int start = text.indexOf("${", i);
+            if (start == -1) {
+                result.append(text.substring(i));
+                break;
+            }
+            result.append(text, i, start);
+            int end = text.indexOf("}", start + 2);
+            if (end == -1) {
+                result.append(text.substring(start));
+                break;
+            }
+            String placeholder = text.substring(start + 2, end);
+            int colonIdx = placeholder.indexOf(':');
+            String key;
+            String defaultValue;
+            if (colonIdx != -1) {
+                key = placeholder.substring(0, colonIdx);
+                defaultValue = placeholder.substring(colonIdx + 1);
+            } else {
+                key = placeholder;
+                defaultValue = null;
+            }
+            String resolved = getProperty(key, defaultValue);
+            if (resolved != null) {
+                result.append(resolved);
+            }
+            i = end + 1;
+        }
+        return result.toString();
+    }
+}

--- a/summer-beans/src/test/java/com/dianpoint/summer/test/beans/ValueAnnotationTest.java
+++ b/summer-beans/src/test/java/com/dianpoint/summer/test/beans/ValueAnnotationTest.java
@@ -1,0 +1,113 @@
+package com.dianpoint.summer.test.beans;
+
+import com.dianpoint.summer.beans.BeansException;
+import com.dianpoint.summer.beans.factory.annotation.Value;
+import com.dianpoint.summer.beans.factory.annotation.ValueAnnotationBeanPostProcessor;
+import com.dianpoint.summer.beans.factory.config.BeanDefinition;
+import com.dianpoint.summer.beans.factory.support.DefaultListableBeanFactory;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ValueAnnotationTest {
+
+    public static class ValueBean {
+        @Value("${app.name}")
+        private String appName;
+
+        @Value("${app.version:1.0.0}")
+        private String appVersion;
+
+        @Value("${app.port:8080}")
+        private int port;
+
+        @Value("staticValue")
+        private String staticField;
+
+        public String getAppName() {
+            return appName;
+        }
+
+        public String getAppVersion() {
+            return appVersion;
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+        public String getStaticField() {
+            return staticField;
+        }
+    }
+
+    @Test
+    public void testValueInjectionFromProperty() throws BeansException {
+        ValueAnnotationBeanPostProcessor processor = new ValueAnnotationBeanPostProcessor();
+        processor.addProperty("app.name", "SummerApp");
+        DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+        factory.addBeanPostProcessor(processor);
+
+        BeanDefinition bd = new BeanDefinition("valueBean", ValueBean.class.getName());
+        factory.registerBeanDefinition("valueBean", bd);
+
+        ValueBean bean = (ValueBean) factory.getBean("valueBean");
+        assertThat(bean.getAppName()).isEqualTo("SummerApp");
+    }
+
+    @Test
+    public void testValueInjectionWithDefaultValue() throws BeansException {
+        ValueAnnotationBeanPostProcessor processor = new ValueAnnotationBeanPostProcessor();
+        DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+        factory.addBeanPostProcessor(processor);
+
+        BeanDefinition bd = new BeanDefinition("valueBean", ValueBean.class.getName());
+        factory.registerBeanDefinition("valueBean", bd);
+
+        ValueBean bean = (ValueBean) factory.getBean("valueBean");
+        assertThat(bean.getAppVersion()).isEqualTo("1.0.0");
+    }
+
+    @Test
+    public void testValueInjectionForIntType() throws BeansException {
+        ValueAnnotationBeanPostProcessor processor = new ValueAnnotationBeanPostProcessor();
+        processor.addProperty("app.port", "9090");
+        DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+        factory.addBeanPostProcessor(processor);
+
+        BeanDefinition bd = new BeanDefinition("valueBean", ValueBean.class.getName());
+        factory.registerBeanDefinition("valueBean", bd);
+
+        ValueBean bean = (ValueBean) factory.getBean("valueBean");
+        assertThat(bean.getPort()).isEqualTo(9090);
+    }
+
+    @Test
+    public void testValueInjectionStaticValue() throws BeansException {
+        ValueAnnotationBeanPostProcessor processor = new ValueAnnotationBeanPostProcessor();
+        DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+        factory.addBeanPostProcessor(processor);
+
+        BeanDefinition bd = new BeanDefinition("valueBean", ValueBean.class.getName());
+        factory.registerBeanDefinition("valueBean", bd);
+
+        ValueBean bean = (ValueBean) factory.getBean("valueBean");
+        assertThat(bean.getStaticField()).isEqualTo("staticValue");
+    }
+
+    @Test
+    public void testPropertyResolverContainsProperty() {
+        ValueAnnotationBeanPostProcessor processor = new ValueAnnotationBeanPostProcessor();
+        processor.addProperty("my.key", "myValue");
+        assertThat(processor.getPropertyResolver().containsProperty("my.key")).isTrue();
+        assertThat(processor.getPropertyResolver().containsProperty("nonexistent")).isFalse();
+    }
+
+    @Test
+    public void testPropertyResolverGetPropertyWithDefault() {
+        ValueAnnotationBeanPostProcessor processor = new ValueAnnotationBeanPostProcessor();
+        processor.addProperty("my.key", "myValue");
+        assertThat(processor.getPropertyResolver().getProperty("my.key", "default")).isEqualTo("myValue");
+        assertThat(processor.getPropertyResolver().getProperty("nonexistent", "default")).isEqualTo("default");
+    }
+}


### PR DESCRIPTION
## Summary

Add @Value annotation support for field-level property injection with ${placeholder} resolution.

### Changes
- **`@Value`**: Field annotation supporting `${key}` and `${key:default}` syntax
- **`SimplePropertyResolver`**: Implements `PropertyResolver` with ConcurrentHashMap backing and placeholder resolution
- **`ValueAnnotationBeanPostProcessor`**: BeanPostProcessor that resolves `@Value` expressions and injects values (supports String, int, long, boolean)
- **`ValueAnnotationTest`**: 6 tests covering property injection, default values, type conversion, static values, and PropertyResolver API

### Verification
```
mvn test -pl summer-beans  # 106 tests pass, 0 failures
```