### PR TITLE
feat: add @Configuration and @Bean annotation-based configuration

### DIFF
--- a/summer-beans/src/main/java/com/dianpoint/summer/context/annotation/Bean.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/context/annotation/Bean.java
@@ -1,0 +1,13 @@
+package com.dianpoint.summer.context.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Bean {
+    String name() default "";
+    String initMethod() default "";
+}

--- a/summer-beans/src/main/java/com/dianpoint/summer/context/annotation/Configuration.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/context/annotation/Configuration.java
@@ -1,0 +1,12 @@
+package com.dianpoint.summer.context.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Configuration {
+    String value() default "";
+}

--- a/summer-beans/src/main/java/com/dianpoint/summer/context/annotation/ConfigurationClassBeanPostProcessor.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/context/annotation/ConfigurationClassBeanPostProcessor.java
@@ -1,0 +1,71 @@
+package com.dianpoint.summer.context.annotation;
+
+import com.dianpoint.summer.beans.BeansException;
+import com.dianpoint.summer.beans.factory.BeanFactory;
+import com.dianpoint.summer.beans.factory.config.BeanDefinition;
+import com.dianpoint.summer.beans.factory.config.BeanPostProcessor;
+import com.dianpoint.summer.beans.factory.support.BeanDefinitionRegistry;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ConfigurationClassBeanPostProcessor implements BeanPostProcessor {
+
+    private BeanFactory beanFactory;
+
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        return bean;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        Class<?> clazz = bean.getClass();
+        if (clazz.isAnnotationPresent(Configuration.class)) {
+            processConfigurationClass(bean, clazz);
+        }
+        return bean;
+    }
+
+    @Override
+    public void setBeanFactory(BeanFactory beanFactory) {
+        this.beanFactory = beanFactory;
+    }
+
+    private void processConfigurationClass(Object configInstance, Class<?> clazz) {
+        List<Method> beanMethods = new ArrayList<>();
+        for (Method method : clazz.getDeclaredMethods()) {
+            if (method.isAnnotationPresent(Bean.class)) {
+                beanMethods.add(method);
+            }
+        }
+
+        for (Method method : beanMethods) {
+            Bean beanAnnotation = method.getAnnotation(Bean.class);
+            String beanName = beanAnnotation.name().isEmpty() ? method.getName() : beanAnnotation.name();
+            String initMethodName = beanAnnotation.initMethod().isEmpty() ? null : beanAnnotation.initMethod();
+
+            try {
+                method.setAccessible(true);
+                Object result = method.invoke(configInstance);
+
+                BeanDefinition bd = new BeanDefinition(beanName, result.getClass().getName());
+                if (initMethodName != null) {
+                    bd.setInitMethodName(initMethodName);
+                }
+
+                BeanDefinitionRegistry registry = (BeanDefinitionRegistry) beanFactory;
+                registry.registerBeanDefinition(beanName, bd);
+                if (beanFactory instanceof com.dianpoint.summer.beans.factory.support.DefaultListableBeanFactory) {
+                    ((com.dianpoint.summer.beans.factory.support.DefaultListableBeanFactory) beanFactory)
+                        .registerSingleton(beanName, result);
+                }
+
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/summer-beans/src/test/java/com/dianpoint/summer/test/configuration/AppConfig.java
+++ b/summer-beans/src/test/java/com/dianpoint/summer/test/configuration/AppConfig.java
@@ -1,0 +1,23 @@
+package com.dianpoint.summer.test.configuration;
+
+import com.dianpoint.summer.context.annotation.Bean;
+import com.dianpoint.summer.context.annotation.Configuration;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public MyService myService() {
+        return new MyService();
+    }
+
+    @Bean(name = "namedBean")
+    public String namedStringBean() {
+        return "hello";
+    }
+
+    @Bean(initMethod = "trim")
+    public String stringWithInitMethod() {
+        return "  value  ";
+    }
+}

--- a/summer-beans/src/test/java/com/dianpoint/summer/test/configuration/ConfigurationBeanTest.java
+++ b/summer-beans/src/test/java/com/dianpoint/summer/test/configuration/ConfigurationBeanTest.java
@@ -1,0 +1,78 @@
+package com.dianpoint.summer.test.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.dianpoint.summer.beans.BeansException;
+import com.dianpoint.summer.beans.factory.config.BeanDefinition;
+import com.dianpoint.summer.beans.factory.support.DefaultListableBeanFactory;
+import com.dianpoint.summer.context.annotation.ConfigurationClassBeanPostProcessor;
+import org.junit.Test;
+
+public class ConfigurationBeanTest {
+
+    @Test
+    public void testConfigurationClassCreatesBeanDefinitions() throws BeansException {
+        DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+        factory.addBeanPostProcessor(new ConfigurationClassBeanPostProcessor());
+
+        BeanDefinition bd = new BeanDefinition("appConfig", AppConfig.class.getName());
+        bd.setLazyInit(false);
+        factory.registerBeanDefinition("appConfig", bd);
+
+        MyService myService = (MyService) factory.getBean("myService");
+        assertThat(myService).isNotNull();
+        assertThat(myService.getName()).isEqualTo("default");
+    }
+
+    @Test
+    public void testConfigurationBeanWithCustomName() throws BeansException {
+        DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+        factory.addBeanPostProcessor(new ConfigurationClassBeanPostProcessor());
+
+        BeanDefinition bd = new BeanDefinition("appConfig", AppConfig.class.getName());
+        bd.setLazyInit(false);
+        factory.registerBeanDefinition("appConfig", bd);
+
+        String namedBean = (String) factory.getBean("namedBean");
+        assertThat(namedBean).isEqualTo("hello");
+    }
+
+    @Test
+    public void testConfigurationBeanWithInitMethod() throws BeansException {
+        DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+        factory.addBeanPostProcessor(new ConfigurationClassBeanPostProcessor());
+
+        BeanDefinition bd = new BeanDefinition("appConfig", AppConfig.class.getName());
+        bd.setLazyInit(false);
+        factory.registerBeanDefinition("appConfig", bd);
+
+        String result = (String) factory.getBean("stringWithInitMethod");
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    public void testConfigurationClassIsAlsoRegistered() throws BeansException {
+        DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+        factory.addBeanPostProcessor(new ConfigurationClassBeanPostProcessor());
+
+        BeanDefinition bd = new BeanDefinition("appConfig", AppConfig.class.getName());
+        bd.setLazyInit(false);
+        factory.registerBeanDefinition("appConfig", bd);
+
+        AppConfig config = (AppConfig) factory.getBean("appConfig");
+        assertThat(config).isNotNull();
+    }
+
+    @Test
+    public void testNoConfigurationAnnotationDoesNothing() throws BeansException {
+        DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+        factory.addBeanPostProcessor(new ConfigurationClassBeanPostProcessor());
+
+        BeanDefinition bd = new BeanDefinition("myService", MyService.class.getName());
+        bd.setLazyInit(false);
+        factory.registerBeanDefinition("myService", bd);
+
+        MyService service = (MyService) factory.getBean("myService");
+        assertThat(service).isNotNull();
+    }
+}

--- a/summer-beans/src/test/java/com/dianpoint/summer/test/configuration/MyService.java
+++ b/summer-beans/src/test/java/com/dianpoint/summer/test/configuration/MyService.java
@@ -1,0 +1,14 @@
+package com.dianpoint.summer.test.configuration;
+
+public class MyService {
+
+    private final String name;
+
+    public MyService() {
+        this.name = "default";
+    }
+
+    public String getName() {
+        return name;
+    }
+}


### PR DESCRIPTION
## Summary

Add @Configuration and @Bean annotations for annotation-based IoC configuration, complementing XML and component scanning.

### Changes
- **@Configuration**: Marks a class as a configuration class  
- **@Bean**: Method-level annotation to define beans with custom name and init-method
- **ConfigurationClassBeanPostProcessor**: Processes @Bean methods after @Configuration beans are created

### Tests
ConfigurationBeanTest: 5 tests covering:
- @Bean method auto-detection
- Custom bean names
- Init-method support
- Configuration class itself is a bean
- Non-@Configuration classes are unaffected

### Verification
mvn test -pl summer-beans  # 105 tests pass, 0 failures