### PR TITLE
feat: add Pointcut interface and NameMatchMethodPointcut for AOP filtering

### DIFF
--- a/summer-beans/src/main/java/com/dianpoint/summer/aop/Advisor.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/aop/Advisor.java
@@ -12,4 +12,8 @@ public interface Advisor {
     void setMethodInterceptor(MethodInterceptor methodInterceptor);
 
     Advice getAdvice();
+
+    Pointcut getPointcut();
+
+    void setPointcut(Pointcut pointcut);
 }

--- a/summer-beans/src/main/java/com/dianpoint/summer/aop/DefaultAdvisor.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/aop/DefaultAdvisor.java
@@ -8,6 +8,7 @@ package com.dianpoint.summer.aop;
 public class DefaultAdvisor implements Advisor {
 
     private MethodInterceptor methodInterceptor;
+    private Pointcut pointcut;
 
     @Override
     public MethodInterceptor getMethodInterceptor() {
@@ -22,5 +23,15 @@ public class DefaultAdvisor implements Advisor {
     @Override
     public Advice getAdvice() {
         return methodInterceptor;
+    }
+
+    @Override
+    public Pointcut getPointcut() {
+        return pointcut;
+    }
+
+    @Override
+    public void setPointcut(Pointcut pointcut) {
+        this.pointcut = pointcut;
     }
 }

--- a/summer-beans/src/main/java/com/dianpoint/summer/aop/JdkDynamicAopProxy.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/aop/JdkDynamicAopProxy.java
@@ -29,10 +29,15 @@ public class JdkDynamicAopProxy implements AopProxy, InvocationHandler {
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
         if (this.advisor == null || this.advisor.getMethodInterceptor() == null) {
-            // 没有配置拦截器时，直接委托给目标对象
             return method.invoke(target, args);
         }
         Class<?> targetClass = target != null ? target.getClass() : null;
+
+        Pointcut pointcut = this.advisor.getPointcut();
+        if (pointcut != null && !pointcut.matches(method, targetClass)) {
+            return method.invoke(target, args);
+        }
+
         MethodInterceptor interceptor = this.advisor.getMethodInterceptor();
         ReflectiveMethodInvocation invocation =
             new ReflectiveMethodInvocation(proxy, target, method, args, targetClass);

--- a/summer-beans/src/main/java/com/dianpoint/summer/aop/NameMatchMethodPointcut.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/aop/NameMatchMethodPointcut.java
@@ -1,0 +1,50 @@
+package com.dianpoint.summer.aop;
+
+import java.lang.reflect.Method;
+
+public class NameMatchMethodPointcut implements Pointcut {
+
+    private String mappedName;
+
+    public NameMatchMethodPointcut() {
+    }
+
+    public NameMatchMethodPointcut(String mappedName) {
+        this.mappedName = mappedName;
+    }
+
+    public void setMappedName(String mappedName) {
+        this.mappedName = mappedName;
+    }
+
+    public String getMappedName() {
+        return mappedName;
+    }
+
+    @Override
+    public boolean matches(Method method, Class<?> targetClass) {
+        if (mappedName == null || mappedName.isEmpty()) {
+            return true;
+        }
+        return isMatch(method.getName(), mappedName);
+    }
+
+    private boolean isMatch(String methodName, String pattern) {
+        if (pattern.equals("*")) {
+            return true;
+        }
+        if (pattern.startsWith("*")) {
+            return methodName.endsWith(pattern.substring(1));
+        }
+        if (pattern.endsWith("*")) {
+            return methodName.startsWith(pattern.substring(0, pattern.length() - 1));
+        }
+        if (pattern.contains("*")) {
+            int starIdx = pattern.indexOf('*');
+            String prefix = pattern.substring(0, starIdx);
+            String suffix = pattern.substring(starIdx + 1);
+            return methodName.startsWith(prefix) && methodName.endsWith(suffix);
+        }
+        return methodName.equals(pattern);
+    }
+}

--- a/summer-beans/src/main/java/com/dianpoint/summer/aop/Pointcut.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/aop/Pointcut.java
@@ -1,0 +1,8 @@
+package com.dianpoint.summer.aop;
+
+import java.lang.reflect.Method;
+
+public interface Pointcut {
+
+    boolean matches(Method method, Class<?> targetClass);
+}

--- a/summer-beans/src/test/java/com/dianpoint/summer/aop/NameMatchMethodPointcutTest.java
+++ b/summer-beans/src/test/java/com/dianpoint/summer/aop/NameMatchMethodPointcutTest.java
@@ -1,0 +1,69 @@
+package com.dianpoint.summer.aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+
+public class NameMatchMethodPointcutTest {
+
+    public static class TestService {
+        public void doAction() {}
+        public String getName() { return "test"; }
+        public void processOrder() {}
+        public void processPayment() {}
+        public void doSomething() {}
+        protected void protectedMethod() {}
+    }
+
+    @Test
+    public void testExactMatch() throws Exception {
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut("doAction");
+        Method method = TestService.class.getMethod("doAction");
+        assertThat(pointcut.matches(method, TestService.class)).isTrue();
+    }
+
+    @Test
+    public void testExactMismatch() throws Exception {
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut("doAction");
+        Method method = TestService.class.getMethod("getName");
+        assertThat(pointcut.matches(method, TestService.class)).isFalse();
+    }
+
+    @Test
+    public void testWildcardPrefix() throws Exception {
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut("process*");
+        assertThat(pointcut.matches(TestService.class.getMethod("processOrder"), TestService.class)).isTrue();
+        assertThat(pointcut.matches(TestService.class.getMethod("processPayment"), TestService.class)).isTrue();
+        assertThat(pointcut.matches(TestService.class.getMethod("doAction"), TestService.class)).isFalse();
+    }
+
+    @Test
+    public void testWildcardSuffix() throws Exception {
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut("*Action");
+        assertThat(pointcut.matches(TestService.class.getMethod("doAction"), TestService.class)).isTrue();
+        assertThat(pointcut.matches(TestService.class.getMethod("getName"), TestService.class)).isFalse();
+    }
+
+    @Test
+    public void testWildcardBothEnds() throws Exception {
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut("do*ing");
+        assertThat(pointcut.matches(TestService.class.getMethod("doSomething"), TestService.class)).isTrue();
+        assertThat(pointcut.matches(TestService.class.getMethod("doAction"), TestService.class)).isFalse();
+    }
+
+    @Test
+    public void testSingleAsterisk() throws Exception {
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut("*");
+        assertThat(pointcut.matches(TestService.class.getMethod("doAction"), TestService.class)).isTrue();
+        assertThat(pointcut.matches(TestService.class.getMethod("getName"), TestService.class)).isTrue();
+    }
+
+    @Test
+    public void testNullMappedNameMatchesAll() throws Exception {
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut();
+        assertThat(pointcut.matches(TestService.class.getMethod("doAction"), TestService.class)).isTrue();
+        assertThat(pointcut.matches(TestService.class.getMethod("getName"), TestService.class)).isTrue();
+    }
+}

--- a/summer-beans/src/test/java/com/dianpoint/summer/aop/PointcutProxyTest.java
+++ b/summer-beans/src/test/java/com/dianpoint/summer/aop/PointcutProxyTest.java
@@ -1,0 +1,94 @@
+package com.dianpoint.summer.aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+public class PointcutProxyTest {
+
+    public interface Calculator {
+        int add(int a, int b);
+        int subtract(int a, int b);
+    }
+
+    public static class CalculatorImpl implements Calculator {
+        @Override
+        public int add(int a, int b) {
+            return a + b;
+        }
+
+        @Override
+        public int subtract(int a, int b) {
+            return a - b;
+        }
+    }
+
+    public static class LoggingAdvice implements MethodBeforeAdvice {
+        private final AtomicBoolean invoked = new AtomicBoolean(false);
+
+        @Override
+        public void before(java.lang.reflect.Method method, Object[] args, Object target) throws Throwable {
+            invoked.set(true);
+        }
+
+        public boolean isInvoked() {
+            return invoked.get();
+        }
+    }
+
+    @Test
+    public void testPointcutMatchesAndInterceptorInvoked() {
+        LoggingAdvice advice = new LoggingAdvice();
+        MethodBeforeAdviceInterceptor interceptor = new MethodBeforeAdviceInterceptor(advice);
+
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut("add");
+        DefaultAdvisor advisor = new DefaultAdvisor();
+        advisor.setMethodInterceptor(interceptor);
+        advisor.setPointcut(pointcut);
+
+        CalculatorImpl target = new CalculatorImpl();
+        JdkDynamicAopProxy aopProxy = new JdkDynamicAopProxy(target, advisor);
+        Calculator proxy = (Calculator) aopProxy.getProxy();
+
+        int result = proxy.add(1, 2);
+        assertThat(result).isEqualTo(3);
+        assertThat(advice.isInvoked()).isTrue();
+    }
+
+    @Test
+    public void testPointcutDoesNotMatchAndInterceptorSkipped() {
+        LoggingAdvice advice = new LoggingAdvice();
+        MethodBeforeAdviceInterceptor interceptor = new MethodBeforeAdviceInterceptor(advice);
+
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut("add");
+        DefaultAdvisor advisor = new DefaultAdvisor();
+        advisor.setMethodInterceptor(interceptor);
+        advisor.setPointcut(pointcut);
+
+        CalculatorImpl target = new CalculatorImpl();
+        JdkDynamicAopProxy aopProxy = new JdkDynamicAopProxy(target, advisor);
+        Calculator proxy = (Calculator) aopProxy.getProxy();
+
+        int result = proxy.subtract(5, 3);
+        assertThat(result).isEqualTo(2);
+        assertThat(advice.isInvoked()).isFalse();
+    }
+
+    @Test
+    public void testNoPointcutMeansMatchAll() {
+        LoggingAdvice advice = new LoggingAdvice();
+        MethodBeforeAdviceInterceptor interceptor = new MethodBeforeAdviceInterceptor(advice);
+
+        DefaultAdvisor advisor = new DefaultAdvisor();
+        advisor.setMethodInterceptor(interceptor);
+
+        CalculatorImpl target = new CalculatorImpl();
+        JdkDynamicAopProxy aopProxy = new JdkDynamicAopProxy(target, advisor);
+        Calculator proxy = (Calculator) aopProxy.getProxy();
+
+        proxy.add(1, 2);
+        assertThat(advice.isInvoked()).isTrue();
+    }
+}


### PR DESCRIPTION
## Summary

Add Pointcut mechanism to control which methods get intercepted by AOP. Previously all method calls were intercepted unconditionally.

### Changes
- **Pointcut**: Interface with matches(Method, Class) method
- **NameMatchMethodPointcut**: Supports exact match, do*, *Action, do*ing, and * wildcard patterns
- **Advisor**: Extended with getPointcut/setPointcut
- **DefaultAdvisor**: Implements Pointcut support
- **JdkDynamicAopProxy**: Checks Pointcut before applying interceptors; delegates directly if no match

### Tests
- NameMatchMethodPointcutTest: 7 tests for pattern matching
- PointcutProxyTest: 3 tests for proxy filtering behavior

### Verification
mvn test -pl summer-beans  # 110 tests pass, 0 failures