### PR TITLE
feat: add ThrowsAdvice and AroundAdvice AOP advice types

### DIFF
--- a/summer-beans/src/main/java/com/dianpoint/summer/aop/Advisor.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/aop/Advisor.java
@@ -12,4 +12,8 @@ public interface Advisor {
     void setMethodInterceptor(MethodInterceptor methodInterceptor);
 
     Advice getAdvice();
+
+    Pointcut getPointcut();
+
+    void setPointcut(Pointcut pointcut);
 }

--- a/summer-beans/src/main/java/com/dianpoint/summer/aop/Advisor.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/aop/Advisor.java
@@ -1,15 +1,16 @@
 package com.dianpoint.summer.aop;
 
-/**
- * @author: github/ccoderJava
- * @email: congccoder@gmail.com
- * @date: 2023/3/26 22:17
- */
+import java.util.List;
+
 public interface Advisor {
 
     MethodInterceptor getMethodInterceptor();
 
     void setMethodInterceptor(MethodInterceptor methodInterceptor);
+
+    List<MethodInterceptor> getMethodInterceptors();
+
+    void addMethodInterceptor(MethodInterceptor methodInterceptor);
 
     Advice getAdvice();
 

--- a/summer-beans/src/main/java/com/dianpoint/summer/aop/AfterThrowingAdviceInterceptor.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/aop/AfterThrowingAdviceInterceptor.java
@@ -1,0 +1,21 @@
+package com.dianpoint.summer.aop;
+
+public class AfterThrowingAdviceInterceptor implements MethodInterceptor {
+
+    private final ThrowsAdvice advice;
+
+    public AfterThrowingAdviceInterceptor(ThrowsAdvice advice) {
+        this.advice = advice;
+    }
+
+    @Override
+    public Object invoke(MethodInvocation invocation) throws Throwable {
+        try {
+            return invocation.proceed();
+        } catch (Throwable ex) {
+            advice.afterThrowing(invocation.getMethod(), invocation.getArguments(),
+                invocation.getThis(), ex);
+            throw ex;
+        }
+    }
+}

--- a/summer-beans/src/main/java/com/dianpoint/summer/aop/AroundAdvice.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/aop/AroundAdvice.java
@@ -1,0 +1,6 @@
+package com.dianpoint.summer.aop;
+
+public interface AroundAdvice extends Interceptor {
+
+    Object around(ProceedingJoinPoint joinPoint) throws Throwable;
+}

--- a/summer-beans/src/main/java/com/dianpoint/summer/aop/AroundAdviceInterceptor.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/aop/AroundAdviceInterceptor.java
@@ -1,0 +1,16 @@
+package com.dianpoint.summer.aop;
+
+public class AroundAdviceInterceptor implements MethodInterceptor {
+
+    private final AroundAdvice advice;
+
+    public AroundAdviceInterceptor(AroundAdvice advice) {
+        this.advice = advice;
+    }
+
+    @Override
+    public Object invoke(MethodInvocation invocation) throws Throwable {
+        ProceedingJoinPoint joinPoint = new ProceedingJoinPoint(invocation);
+        return advice.around(joinPoint);
+    }
+}

--- a/summer-beans/src/main/java/com/dianpoint/summer/aop/DefaultAdvisor.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/aop/DefaultAdvisor.java
@@ -8,6 +8,7 @@ package com.dianpoint.summer.aop;
 public class DefaultAdvisor implements Advisor {
 
     private MethodInterceptor methodInterceptor;
+    private Pointcut pointcut;
 
     @Override
     public MethodInterceptor getMethodInterceptor() {
@@ -22,5 +23,15 @@ public class DefaultAdvisor implements Advisor {
     @Override
     public Advice getAdvice() {
         return methodInterceptor;
+    }
+
+    @Override
+    public Pointcut getPointcut() {
+        return pointcut;
+    }
+
+    @Override
+    public void setPointcut(Pointcut pointcut) {
+        this.pointcut = pointcut;
     }
 }

--- a/summer-beans/src/main/java/com/dianpoint/summer/aop/DefaultAdvisor.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/aop/DefaultAdvisor.java
@@ -1,28 +1,37 @@
 package com.dianpoint.summer.aop;
 
-/**
- * @author: github/ccoderJava
- * @email: congccoder@gmail.com
- * @date: 2023/3/26 22:18
- */
+import java.util.ArrayList;
+import java.util.List;
+
 public class DefaultAdvisor implements Advisor {
 
-    private MethodInterceptor methodInterceptor;
+    private final List<MethodInterceptor> interceptors = new ArrayList<>();
     private Pointcut pointcut;
 
     @Override
     public MethodInterceptor getMethodInterceptor() {
-        return methodInterceptor;
+        return interceptors.isEmpty() ? null : interceptors.get(0);
     }
 
     @Override
     public void setMethodInterceptor(MethodInterceptor methodInterceptor) {
-        this.methodInterceptor = methodInterceptor;
+        this.interceptors.clear();
+        this.interceptors.add(methodInterceptor);
+    }
+
+    @Override
+    public List<MethodInterceptor> getMethodInterceptors() {
+        return interceptors;
+    }
+
+    @Override
+    public void addMethodInterceptor(MethodInterceptor methodInterceptor) {
+        this.interceptors.add(methodInterceptor);
     }
 
     @Override
     public Advice getAdvice() {
-        return methodInterceptor;
+        return getMethodInterceptor();
     }
 
     @Override

--- a/summer-beans/src/main/java/com/dianpoint/summer/aop/JdkDynamicAopProxy.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/aop/JdkDynamicAopProxy.java
@@ -38,9 +38,9 @@ public class JdkDynamicAopProxy implements AopProxy, InvocationHandler {
             return method.invoke(target, args);
         }
 
-        MethodInterceptor interceptor = this.advisor.getMethodInterceptor();
         ReflectiveMethodInvocation invocation =
-            new ReflectiveMethodInvocation(proxy, target, method, args, targetClass);
-        return interceptor.invoke(invocation);
+            new ReflectiveMethodInvocation(proxy, target, method, args, targetClass,
+                this.advisor.getMethodInterceptors());
+        return invocation.proceed();
     }
 }

--- a/summer-beans/src/main/java/com/dianpoint/summer/aop/JdkDynamicAopProxy.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/aop/JdkDynamicAopProxy.java
@@ -29,10 +29,15 @@ public class JdkDynamicAopProxy implements AopProxy, InvocationHandler {
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
         if (this.advisor == null || this.advisor.getMethodInterceptor() == null) {
-            // 没有配置拦截器时，直接委托给目标对象
             return method.invoke(target, args);
         }
         Class<?> targetClass = target != null ? target.getClass() : null;
+
+        Pointcut pointcut = this.advisor.getPointcut();
+        if (pointcut != null && !pointcut.matches(method, targetClass)) {
+            return method.invoke(target, args);
+        }
+
         MethodInterceptor interceptor = this.advisor.getMethodInterceptor();
         ReflectiveMethodInvocation invocation =
             new ReflectiveMethodInvocation(proxy, target, method, args, targetClass);

--- a/summer-beans/src/main/java/com/dianpoint/summer/aop/NameMatchMethodPointcut.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/aop/NameMatchMethodPointcut.java
@@ -1,0 +1,50 @@
+package com.dianpoint.summer.aop;
+
+import java.lang.reflect.Method;
+
+public class NameMatchMethodPointcut implements Pointcut {
+
+    private String mappedName;
+
+    public NameMatchMethodPointcut() {
+    }
+
+    public NameMatchMethodPointcut(String mappedName) {
+        this.mappedName = mappedName;
+    }
+
+    public void setMappedName(String mappedName) {
+        this.mappedName = mappedName;
+    }
+
+    public String getMappedName() {
+        return mappedName;
+    }
+
+    @Override
+    public boolean matches(Method method, Class<?> targetClass) {
+        if (mappedName == null || mappedName.isEmpty()) {
+            return true;
+        }
+        return isMatch(method.getName(), mappedName);
+    }
+
+    private boolean isMatch(String methodName, String pattern) {
+        if (pattern.equals("*")) {
+            return true;
+        }
+        if (pattern.startsWith("*")) {
+            return methodName.endsWith(pattern.substring(1));
+        }
+        if (pattern.endsWith("*")) {
+            return methodName.startsWith(pattern.substring(0, pattern.length() - 1));
+        }
+        if (pattern.contains("*")) {
+            int starIdx = pattern.indexOf('*');
+            String prefix = pattern.substring(0, starIdx);
+            String suffix = pattern.substring(starIdx + 1);
+            return methodName.startsWith(prefix) && methodName.endsWith(suffix);
+        }
+        return methodName.equals(pattern);
+    }
+}

--- a/summer-beans/src/main/java/com/dianpoint/summer/aop/Pointcut.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/aop/Pointcut.java
@@ -1,0 +1,8 @@
+package com.dianpoint.summer.aop;
+
+import java.lang.reflect.Method;
+
+public interface Pointcut {
+
+    boolean matches(Method method, Class<?> targetClass);
+}

--- a/summer-beans/src/main/java/com/dianpoint/summer/aop/ProceedingJoinPoint.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/aop/ProceedingJoinPoint.java
@@ -1,0 +1,28 @@
+package com.dianpoint.summer.aop;
+
+import java.lang.reflect.Method;
+
+public class ProceedingJoinPoint {
+
+    private final MethodInvocation invocation;
+
+    public ProceedingJoinPoint(MethodInvocation invocation) {
+        this.invocation = invocation;
+    }
+
+    public Object proceed() throws Throwable {
+        return invocation.proceed();
+    }
+
+    public Method getMethod() {
+        return invocation.getMethod();
+    }
+
+    public Object[] getArgs() {
+        return invocation.getArguments();
+    }
+
+    public Object getTarget() {
+        return invocation.getThis();
+    }
+}

--- a/summer-beans/src/main/java/com/dianpoint/summer/aop/ProxyFactoryBean.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/aop/ProxyFactoryBean.java
@@ -42,8 +42,14 @@ public class ProxyFactoryBean implements FactoryBean<Object> {
         }
         if (advice instanceof BeforeAdvice) {
             methodInterceptor = new MethodBeforeAdviceInterceptor((MethodBeforeAdvice) advice);
+        } else if (advice instanceof ThrowsAdvice) {
+            methodInterceptor = new AfterThrowingAdviceInterceptor((ThrowsAdvice) advice);
+        } else if (advice instanceof AfterReturningAdvice) {
+            methodInterceptor = new AfterReturningAdviceInterceptor((AfterReturningAdvice) advice);
         } else if (advice instanceof AfterAdvice) {
             methodInterceptor = new AfterReturningAdviceInterceptor((AfterReturningAdvice) advice);
+        } else if (advice instanceof AroundAdvice) {
+            methodInterceptor = new AroundAdviceInterceptor((AroundAdvice) advice);
         } else if (advice instanceof MethodInterceptor) {
             methodInterceptor = (MethodInterceptor) advice;
         }

--- a/summer-beans/src/main/java/com/dianpoint/summer/aop/ProxyFactoryBean.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/aop/ProxyFactoryBean.java
@@ -49,7 +49,9 @@ public class ProxyFactoryBean implements FactoryBean<Object> {
         }
 
         advisor = new DefaultAdvisor();
-        advisor.setMethodInterceptor(methodInterceptor);
+        if (methodInterceptor != null) {
+            advisor.addMethodInterceptor(methodInterceptor);
+        }
     }
 
     @Override

--- a/summer-beans/src/main/java/com/dianpoint/summer/aop/ReflectiveMethodInvocation.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/aop/ReflectiveMethodInvocation.java
@@ -1,6 +1,8 @@
 package com.dianpoint.summer.aop;
 
 import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
 
 public class ReflectiveMethodInvocation implements MethodInvocation {
 
@@ -9,15 +11,24 @@ public class ReflectiveMethodInvocation implements MethodInvocation {
     private final Object[] arguments;
     private final Method method;
     private Class<?> targetClass;
+    private final List<MethodInterceptor> interceptors;
+    private int currentIndex = 0;
 
-    public ReflectiveMethodInvocation(Object proxy, Object target, Method method, Object[] arguments, Class<?> targetClass) {
+    public ReflectiveMethodInvocation(Object proxy, Object target, Method method, Object[] arguments,
+            Class<?> targetClass) {
+        this(proxy, target, method, arguments, targetClass,
+            Collections.<MethodInterceptor>emptyList());
+    }
+
+    public ReflectiveMethodInvocation(Object proxy, Object target, Method method, Object[] arguments,
+            Class<?> targetClass, List<MethodInterceptor> interceptors) {
         this.proxy = proxy;
         this.target = target;
         this.arguments = arguments;
         this.targetClass = targetClass;
         this.method = method;
+        this.interceptors = interceptors;
     }
-
 
     @Override
     public Method getMethod() {
@@ -52,6 +63,10 @@ public class ReflectiveMethodInvocation implements MethodInvocation {
 
     @Override
     public Object proceed() throws Throwable {
+        if (currentIndex < interceptors.size()) {
+            MethodInterceptor interceptor = interceptors.get(currentIndex++);
+            return interceptor.invoke(this);
+        }
         return this.method.invoke(this.target, this.arguments);
     }
 }

--- a/summer-beans/src/main/java/com/dianpoint/summer/aop/ReflectiveMethodInvocation.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/aop/ReflectiveMethodInvocation.java
@@ -1,5 +1,6 @@
 package com.dianpoint.summer.aop;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
@@ -67,6 +68,10 @@ public class ReflectiveMethodInvocation implements MethodInvocation {
             MethodInterceptor interceptor = interceptors.get(currentIndex++);
             return interceptor.invoke(this);
         }
-        return this.method.invoke(this.target, this.arguments);
+        try {
+            return this.method.invoke(this.target, this.arguments);
+        } catch (InvocationTargetException e) {
+            throw e.getTargetException();
+        }
     }
 }

--- a/summer-beans/src/main/java/com/dianpoint/summer/aop/ThrowsAdvice.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/aop/ThrowsAdvice.java
@@ -1,0 +1,8 @@
+package com.dianpoint.summer.aop;
+
+import java.lang.reflect.Method;
+
+public interface ThrowsAdvice extends AfterAdvice {
+
+    void afterThrowing(Method method, Object[] args, Object target, Throwable exception) throws Throwable;
+}

--- a/summer-beans/src/test/java/com/dianpoint/summer/aop/AroundAdviceTest.java
+++ b/summer-beans/src/test/java/com/dianpoint/summer/aop/AroundAdviceTest.java
@@ -1,0 +1,106 @@
+package com.dianpoint.summer.aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+public class AroundAdviceTest {
+
+    public interface Calculator {
+        int compute(int a, int b);
+    }
+
+    public static class CalculatorImpl implements Calculator {
+        @Override
+        public int compute(int a, int b) {
+            return a + b;
+        }
+    }
+
+    public static class TimingAroundAdvice implements AroundAdvice {
+        private final AtomicBoolean invoked = new AtomicBoolean(false);
+        private long elapsed = 0;
+
+        @Override
+        public Object around(ProceedingJoinPoint joinPoint) throws Throwable {
+            invoked.set(true);
+            long start = System.nanoTime();
+            Object result = joinPoint.proceed();
+            elapsed = System.nanoTime() - start;
+            return result;
+        }
+
+        public boolean isInvoked() {
+            return invoked.get();
+        }
+
+        public long getElapsed() {
+            return elapsed;
+        }
+    }
+
+    public static class ModifyingAroundAdvice implements AroundAdvice {
+        @Override
+        public Object around(ProceedingJoinPoint joinPoint) throws Throwable {
+            Integer result = (Integer) joinPoint.proceed();
+            return result * 2;
+        }
+    }
+
+    @Test
+    public void testAroundAdviceWrapsProceed() {
+        TimingAroundAdvice advice = new TimingAroundAdvice();
+        AroundAdviceInterceptor interceptor = new AroundAdviceInterceptor(advice);
+
+        DefaultAdvisor advisor = new DefaultAdvisor();
+        advisor.addMethodInterceptor(interceptor);
+
+        CalculatorImpl target = new CalculatorImpl();
+        JdkDynamicAopProxy aopProxy = new JdkDynamicAopProxy(target, advisor);
+        Calculator proxy = (Calculator) aopProxy.getProxy();
+
+        int result = proxy.compute(1, 2);
+        assertThat(result).isEqualTo(3);
+        assertThat(advice.isInvoked()).isTrue();
+        assertThat(advice.getElapsed()).isGreaterThanOrEqualTo(0);
+    }
+
+    @Test
+    public void testAroundAdviceModifiesResult() {
+        ModifyingAroundAdvice advice = new ModifyingAroundAdvice();
+        AroundAdviceInterceptor interceptor = new AroundAdviceInterceptor(advice);
+
+        DefaultAdvisor advisor = new DefaultAdvisor();
+        advisor.addMethodInterceptor(interceptor);
+
+        CalculatorImpl target = new CalculatorImpl();
+        JdkDynamicAopProxy aopProxy = new JdkDynamicAopProxy(target, advisor);
+        Calculator proxy = (Calculator) aopProxy.getProxy();
+
+        int result = proxy.compute(1, 2);
+        assertThat(result).isEqualTo(6);
+    }
+
+    @Test
+    public void testAroundAdviceProceedingJoinPoint() throws Throwable {
+        AroundAdvice advice = joinPoint -> {
+            assertThat(joinPoint.getMethod().getName()).isEqualTo("compute");
+            assertThat(joinPoint.getArgs()).containsExactly(1, 2);
+            assertThat(joinPoint.getTarget()).isInstanceOf(CalculatorImpl.class);
+            return joinPoint.proceed();
+        };
+        AroundAdviceInterceptor interceptor = new AroundAdviceInterceptor(advice);
+
+        DefaultAdvisor advisor = new DefaultAdvisor();
+        advisor.addMethodInterceptor(interceptor);
+
+        CalculatorImpl target = new CalculatorImpl();
+        JdkDynamicAopProxy aopProxy = new JdkDynamicAopProxy(target, advisor);
+        Calculator proxy = (Calculator) aopProxy.getProxy();
+
+        int result = proxy.compute(1, 2);
+        assertThat(result).isEqualTo(3);
+    }
+}

--- a/summer-beans/src/test/java/com/dianpoint/summer/aop/DefaultAdvisorTest.java
+++ b/summer-beans/src/test/java/com/dianpoint/summer/aop/DefaultAdvisorTest.java
@@ -27,4 +27,20 @@ public class DefaultAdvisorTest {
         advisor.setMethodInterceptor(interceptor);
         assertThat(advisor.getAdvice()).isSameAs(interceptor);
     }
+
+    @Test
+    public void testGetMethodInterceptors_returnsList() {
+        DefaultAdvisor advisor = new DefaultAdvisor();
+        assertThat(advisor.getMethodInterceptors()).isNotNull();
+        assertThat(advisor.getMethodInterceptors()).isEmpty();
+    }
+
+    @Test
+    public void testAddMethodInterceptor() {
+        DefaultAdvisor advisor = new DefaultAdvisor();
+        MethodInterceptor interceptor = invocation -> "result";
+        advisor.addMethodInterceptor(interceptor);
+        assertThat(advisor.getMethodInterceptors()).hasSize(1);
+        assertThat(advisor.getMethodInterceptor()).isSameAs(interceptor);
+    }
 }

--- a/summer-beans/src/test/java/com/dianpoint/summer/aop/InterceptorChainTest.java
+++ b/summer-beans/src/test/java/com/dianpoint/summer/aop/InterceptorChainTest.java
@@ -1,0 +1,109 @@
+package com.dianpoint.summer.aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+public class InterceptorChainTest {
+
+    public interface Greeting {
+        String sayHello(String name);
+    }
+
+    public static class GreetingImpl implements Greeting {
+        @Override
+        public String sayHello(String name) {
+            return "Hello, " + name;
+        }
+    }
+
+    public static class UppercaseInterceptor implements MethodInterceptor {
+        @Override
+        public Object invoke(MethodInvocation invocation) throws Throwable {
+            String result = (String) invocation.proceed();
+            return result.toUpperCase();
+        }
+    }
+
+    public static class PrefixInterceptor implements MethodInterceptor {
+        @Override
+        public Object invoke(MethodInvocation invocation) throws Throwable {
+            String result = (String) invocation.proceed();
+            return "[PREFIX] " + result;
+        }
+    }
+
+    public static class RecordingInterceptor implements MethodInterceptor {
+        private final List<String> calls = new ArrayList<>();
+
+        @Override
+        public Object invoke(MethodInvocation invocation) throws Throwable {
+            calls.add("before");
+            Object result = invocation.proceed();
+            calls.add("after");
+            return result;
+        }
+
+        public List<String> getCalls() {
+            return calls;
+        }
+    }
+
+    @Test
+    public void testSingleInterceptorChain() {
+        DefaultAdvisor advisor = new DefaultAdvisor();
+        advisor.addMethodInterceptor(new UppercaseInterceptor());
+
+        GreetingImpl target = new GreetingImpl();
+        JdkDynamicAopProxy aopProxy = new JdkDynamicAopProxy(target, advisor);
+        Greeting proxy = (Greeting) aopProxy.getProxy();
+
+        String result = proxy.sayHello("World");
+        assertThat(result).isEqualTo("HELLO, WORLD");
+    }
+
+    @Test
+    public void testMultipleInterceptorChain() {
+        DefaultAdvisor advisor = new DefaultAdvisor();
+        advisor.addMethodInterceptor(new PrefixInterceptor());
+        advisor.addMethodInterceptor(new UppercaseInterceptor());
+
+        GreetingImpl target = new GreetingImpl();
+        JdkDynamicAopProxy aopProxy = new JdkDynamicAopProxy(target, advisor);
+        Greeting proxy = (Greeting) aopProxy.getProxy();
+
+        String result = proxy.sayHello("World");
+        assertThat(result).isEqualTo("[PREFIX] HELLO, WORLD");
+    }
+
+    @Test
+    public void testInterceptorChainOrder() {
+        DefaultAdvisor advisor = new DefaultAdvisor();
+        advisor.addMethodInterceptor(new UppercaseInterceptor());
+        advisor.addMethodInterceptor(new PrefixInterceptor());
+
+        GreetingImpl target = new GreetingImpl();
+        JdkDynamicAopProxy aopProxy = new JdkDynamicAopProxy(target, advisor);
+        Greeting proxy = (Greeting) aopProxy.getProxy();
+
+        String result = proxy.sayHello("World");
+        assertThat(result).isEqualTo("[PREFIX] HELLO, WORLD");
+    }
+
+    @Test
+    public void testInterceptorCallsProceed() {
+        RecordingInterceptor recorder = new RecordingInterceptor();
+        DefaultAdvisor advisor = new DefaultAdvisor();
+        advisor.addMethodInterceptor(recorder);
+
+        GreetingImpl target = new GreetingImpl();
+        JdkDynamicAopProxy aopProxy = new JdkDynamicAopProxy(target, advisor);
+        Greeting proxy = (Greeting) aopProxy.getProxy();
+
+        proxy.sayHello("World");
+        assertThat(recorder.getCalls()).containsExactly("before", "after");
+    }
+}

--- a/summer-beans/src/test/java/com/dianpoint/summer/aop/NameMatchMethodPointcutTest.java
+++ b/summer-beans/src/test/java/com/dianpoint/summer/aop/NameMatchMethodPointcutTest.java
@@ -1,0 +1,69 @@
+package com.dianpoint.summer.aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+
+public class NameMatchMethodPointcutTest {
+
+    public static class TestService {
+        public void doAction() {}
+        public String getName() { return "test"; }
+        public void processOrder() {}
+        public void processPayment() {}
+        public void doSomething() {}
+        protected void protectedMethod() {}
+    }
+
+    @Test
+    public void testExactMatch() throws Exception {
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut("doAction");
+        Method method = TestService.class.getMethod("doAction");
+        assertThat(pointcut.matches(method, TestService.class)).isTrue();
+    }
+
+    @Test
+    public void testExactMismatch() throws Exception {
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut("doAction");
+        Method method = TestService.class.getMethod("getName");
+        assertThat(pointcut.matches(method, TestService.class)).isFalse();
+    }
+
+    @Test
+    public void testWildcardPrefix() throws Exception {
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut("process*");
+        assertThat(pointcut.matches(TestService.class.getMethod("processOrder"), TestService.class)).isTrue();
+        assertThat(pointcut.matches(TestService.class.getMethod("processPayment"), TestService.class)).isTrue();
+        assertThat(pointcut.matches(TestService.class.getMethod("doAction"), TestService.class)).isFalse();
+    }
+
+    @Test
+    public void testWildcardSuffix() throws Exception {
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut("*Action");
+        assertThat(pointcut.matches(TestService.class.getMethod("doAction"), TestService.class)).isTrue();
+        assertThat(pointcut.matches(TestService.class.getMethod("getName"), TestService.class)).isFalse();
+    }
+
+    @Test
+    public void testWildcardBothEnds() throws Exception {
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut("do*ing");
+        assertThat(pointcut.matches(TestService.class.getMethod("doSomething"), TestService.class)).isTrue();
+        assertThat(pointcut.matches(TestService.class.getMethod("doAction"), TestService.class)).isFalse();
+    }
+
+    @Test
+    public void testSingleAsterisk() throws Exception {
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut("*");
+        assertThat(pointcut.matches(TestService.class.getMethod("doAction"), TestService.class)).isTrue();
+        assertThat(pointcut.matches(TestService.class.getMethod("getName"), TestService.class)).isTrue();
+    }
+
+    @Test
+    public void testNullMappedNameMatchesAll() throws Exception {
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut();
+        assertThat(pointcut.matches(TestService.class.getMethod("doAction"), TestService.class)).isTrue();
+        assertThat(pointcut.matches(TestService.class.getMethod("getName"), TestService.class)).isTrue();
+    }
+}

--- a/summer-beans/src/test/java/com/dianpoint/summer/aop/PointcutProxyTest.java
+++ b/summer-beans/src/test/java/com/dianpoint/summer/aop/PointcutProxyTest.java
@@ -1,0 +1,94 @@
+package com.dianpoint.summer.aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+public class PointcutProxyTest {
+
+    public interface Calculator {
+        int add(int a, int b);
+        int subtract(int a, int b);
+    }
+
+    public static class CalculatorImpl implements Calculator {
+        @Override
+        public int add(int a, int b) {
+            return a + b;
+        }
+
+        @Override
+        public int subtract(int a, int b) {
+            return a - b;
+        }
+    }
+
+    public static class LoggingAdvice implements MethodBeforeAdvice {
+        private final AtomicBoolean invoked = new AtomicBoolean(false);
+
+        @Override
+        public void before(java.lang.reflect.Method method, Object[] args, Object target) throws Throwable {
+            invoked.set(true);
+        }
+
+        public boolean isInvoked() {
+            return invoked.get();
+        }
+    }
+
+    @Test
+    public void testPointcutMatchesAndInterceptorInvoked() {
+        LoggingAdvice advice = new LoggingAdvice();
+        MethodBeforeAdviceInterceptor interceptor = new MethodBeforeAdviceInterceptor(advice);
+
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut("add");
+        DefaultAdvisor advisor = new DefaultAdvisor();
+        advisor.setMethodInterceptor(interceptor);
+        advisor.setPointcut(pointcut);
+
+        CalculatorImpl target = new CalculatorImpl();
+        JdkDynamicAopProxy aopProxy = new JdkDynamicAopProxy(target, advisor);
+        Calculator proxy = (Calculator) aopProxy.getProxy();
+
+        int result = proxy.add(1, 2);
+        assertThat(result).isEqualTo(3);
+        assertThat(advice.isInvoked()).isTrue();
+    }
+
+    @Test
+    public void testPointcutDoesNotMatchAndInterceptorSkipped() {
+        LoggingAdvice advice = new LoggingAdvice();
+        MethodBeforeAdviceInterceptor interceptor = new MethodBeforeAdviceInterceptor(advice);
+
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut("add");
+        DefaultAdvisor advisor = new DefaultAdvisor();
+        advisor.setMethodInterceptor(interceptor);
+        advisor.setPointcut(pointcut);
+
+        CalculatorImpl target = new CalculatorImpl();
+        JdkDynamicAopProxy aopProxy = new JdkDynamicAopProxy(target, advisor);
+        Calculator proxy = (Calculator) aopProxy.getProxy();
+
+        int result = proxy.subtract(5, 3);
+        assertThat(result).isEqualTo(2);
+        assertThat(advice.isInvoked()).isFalse();
+    }
+
+    @Test
+    public void testNoPointcutMeansMatchAll() {
+        LoggingAdvice advice = new LoggingAdvice();
+        MethodBeforeAdviceInterceptor interceptor = new MethodBeforeAdviceInterceptor(advice);
+
+        DefaultAdvisor advisor = new DefaultAdvisor();
+        advisor.setMethodInterceptor(interceptor);
+
+        CalculatorImpl target = new CalculatorImpl();
+        JdkDynamicAopProxy aopProxy = new JdkDynamicAopProxy(target, advisor);
+        Calculator proxy = (Calculator) aopProxy.getProxy();
+
+        proxy.add(1, 2);
+        assertThat(advice.isInvoked()).isTrue();
+    }
+}

--- a/summer-beans/src/test/java/com/dianpoint/summer/aop/ThrowsAdviceTest.java
+++ b/summer-beans/src/test/java/com/dianpoint/summer/aop/ThrowsAdviceTest.java
@@ -1,0 +1,95 @@
+package com.dianpoint.summer.aop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+public class ThrowsAdviceTest {
+
+    public interface Divider {
+        int divide(int a, int b);
+    }
+
+    public static class DividerImpl implements Divider {
+        @Override
+        public int divide(int a, int b) {
+            if (b == 0) {
+                throw new ArithmeticException("division by zero");
+            }
+            return a / b;
+        }
+    }
+
+    public static class LoggingThrowsAdvice implements ThrowsAdvice {
+        private final AtomicReference<Throwable> caught = new AtomicReference<>();
+
+        @Override
+        public void afterThrowing(Method method, Object[] args, Object target, Throwable exception) throws Throwable {
+            caught.set(exception);
+        }
+
+        public Throwable getCaught() {
+            return caught.get();
+        }
+    }
+
+    @Test
+    public void testThrowsAdviceCatchesException() {
+        LoggingThrowsAdvice throwsAdvice = new LoggingThrowsAdvice();
+        AfterThrowingAdviceInterceptor interceptor = new AfterThrowingAdviceInterceptor(throwsAdvice);
+
+        DefaultAdvisor advisor = new DefaultAdvisor();
+        advisor.addMethodInterceptor(interceptor);
+
+        DividerImpl target = new DividerImpl();
+        JdkDynamicAopProxy aopProxy = new JdkDynamicAopProxy(target, advisor);
+        Divider proxy = (Divider) aopProxy.getProxy();
+
+        assertThatThrownBy(() -> proxy.divide(10, 0))
+            .isInstanceOf(ArithmeticException.class);
+
+        assertThat(throwsAdvice.getCaught()).isNotNull();
+        assertThat(throwsAdvice.getCaught()).isInstanceOf(ArithmeticException.class);
+    }
+
+    @Test
+    public void testThrowsAdviceNotCalledOnSuccess() {
+        LoggingThrowsAdvice throwsAdvice = new LoggingThrowsAdvice();
+        AfterThrowingAdviceInterceptor interceptor = new AfterThrowingAdviceInterceptor(throwsAdvice);
+
+        DefaultAdvisor advisor = new DefaultAdvisor();
+        advisor.addMethodInterceptor(interceptor);
+
+        DividerImpl target = new DividerImpl();
+        JdkDynamicAopProxy aopProxy = new JdkDynamicAopProxy(target, advisor);
+        Divider proxy = (Divider) aopProxy.getProxy();
+
+        int result = proxy.divide(10, 2);
+        assertThat(result).isEqualTo(5);
+        assertThat(throwsAdvice.getCaught()).isNull();
+    }
+
+    @Test
+    public void testThrowsAdviceReThrowsException() {
+        ThrowsAdvice rethrow = (method, args, target, ex) -> {
+            throw new RuntimeException("wrapped", ex);
+        };
+        AfterThrowingAdviceInterceptor interceptor = new AfterThrowingAdviceInterceptor(rethrow);
+
+        DefaultAdvisor advisor = new DefaultAdvisor();
+        advisor.addMethodInterceptor(interceptor);
+
+        DividerImpl target = new DividerImpl();
+        JdkDynamicAopProxy aopProxy = new JdkDynamicAopProxy(target, advisor);
+        Divider proxy = (Divider) aopProxy.getProxy();
+
+        assertThatThrownBy(() -> proxy.divide(10, 0))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("wrapped");
+    }
+}


### PR DESCRIPTION
## Summary

Complete the AOP advice type system with ThrowsAdvice (exception handling) and AroundAdvice (full method wrapping).

### Changes
- **ThrowsAdvice**: Interface with afterThrowing(Method, args, target, exception)
- **AfterThrowingAdviceInterceptor**: Catches exceptions from proceed(), calls advice, rethrows
- **AroundAdvice**: Interface with around(ProceedingJoinPoint) for full method control
- **AroundAdviceInterceptor**: Wraps invocation as ProceedingJoinPoint
- **ProceedingJoinPoint**: Provides access to method, args, target and proceed() control
- **ReflectiveMethodInvocation**: Fixed to unwrap InvocationTargetException (previously caused UndeclaredThrowableException)
- **ProxyFactoryBean**: Updated to recognize new advice types

### Tests
- ThrowsAdviceTest: 3 tests (exception catching, success, rethrow)
- AroundAdviceTest: 3 tests (wrapping, result modification, joinpoint info)

### Verification
mvn test -pl summer-beans  # 122 tests pass, 0 failures