### PR TITLE
feat: implement web MVC layer with HandlerMapping, HandlerAdapter and DispatcherServlet

### DIFF
--- a/summer-beans/src/main/java/com/dianpoint/summer/stereotype/Controller.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/stereotype/Controller.java
@@ -1,0 +1,12 @@
+package com.dianpoint.summer.stereotype;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Controller {
+    String value() default "";
+}

--- a/summer-beans/src/main/java/com/dianpoint/summer/web/DispatcherServlet.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/web/DispatcherServlet.java
@@ -1,18 +1,79 @@
 package com.dianpoint.summer.web;
 
+import com.dianpoint.summer.context.ClassPathXmlApplicationContext;
+import com.dianpoint.summer.web.servlet.HandlerAdapter;
+import com.dianpoint.summer.web.servlet.HandlerMethod;
+import com.dianpoint.summer.web.servlet.HandlerMapping;
+import com.dianpoint.summer.web.servlet.RequestMappingHandlerAdapter;
+import com.dianpoint.summer.web.servlet.RequestMappingHandlerMapping;
+
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
+import java.util.List;
 
-/**
- * @author: github/ccoderJava
- * @email: congccoder@gmail.com
- * @date: 2023/4/4 21:17
- */
 public class DispatcherServlet extends HttpServlet {
+
+    private List<HandlerMapping> handlerMappings;
+    private List<HandlerAdapter> handlerAdapters;
 
     @Override
     public void init(ServletConfig config) throws ServletException {
         super.init(config);
+        String contextConfigLocation = config.getInitParameter("contextConfigLocation");
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(contextConfigLocation);
+
+        handlerMappings = new ArrayList<>();
+        handlerMappings.add(new RequestMappingHandlerMapping(context.getBeanFactory()));
+
+        handlerAdapters = new ArrayList<>();
+        handlerAdapters.add(new RequestMappingHandlerAdapter());
+    }
+
+    @Override
+    protected void service(HttpServletRequest req, HttpServletResponse resp) {
+        try {
+            doDispatch(req, resp);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void doDispatch(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        HandlerMethod handler = getHandler(request);
+        if (handler == null) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        HandlerAdapter adapter = getHandlerAdapter(handler);
+        if (adapter == null) {
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
+        adapter.handle(request, response, handler);
+    }
+
+    private HandlerMethod getHandler(HttpServletRequest request) throws Exception {
+        for (HandlerMapping mapping : handlerMappings) {
+            HandlerMethod handler = mapping.getHandler(request);
+            if (handler != null) {
+                return handler;
+            }
+        }
+        return null;
+    }
+
+    private HandlerAdapter getHandlerAdapter(Object handler) {
+        for (HandlerAdapter adapter : handlerAdapters) {
+            if (adapter.supports(handler)) {
+                return adapter;
+            }
+        }
+        return null;
     }
 }

--- a/summer-beans/src/main/java/com/dianpoint/summer/web/annotation/RequestParam.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/web/annotation/RequestParam.java
@@ -1,0 +1,14 @@
+package com.dianpoint.summer.web.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequestParam {
+    String value() default "";
+    String name() default "";
+    String defaultValue() default "";
+}

--- a/summer-beans/src/main/java/com/dianpoint/summer/web/annotation/ResponseBody.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/web/annotation/ResponseBody.java
@@ -1,0 +1,11 @@
+package com.dianpoint.summer.web.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ResponseBody {
+}

--- a/summer-beans/src/main/java/com/dianpoint/summer/web/servlet/HandlerAdapter.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/web/servlet/HandlerAdapter.java
@@ -1,0 +1,11 @@
+package com.dianpoint.summer.web.servlet;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public interface HandlerAdapter {
+
+    boolean supports(Object handler);
+
+    void handle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception;
+}

--- a/summer-beans/src/main/java/com/dianpoint/summer/web/servlet/HandlerMapping.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/web/servlet/HandlerMapping.java
@@ -1,0 +1,8 @@
+package com.dianpoint.summer.web.servlet;
+
+import javax.servlet.http.HttpServletRequest;
+
+public interface HandlerMapping {
+
+    HandlerMethod getHandler(HttpServletRequest request) throws Exception;
+}

--- a/summer-beans/src/main/java/com/dianpoint/summer/web/servlet/HandlerMethod.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/web/servlet/HandlerMethod.java
@@ -1,0 +1,22 @@
+package com.dianpoint.summer.web.servlet;
+
+import java.lang.reflect.Method;
+
+public class HandlerMethod {
+
+    private final Object bean;
+    private final Method method;
+
+    public HandlerMethod(Object bean, Method method) {
+        this.bean = bean;
+        this.method = method;
+    }
+
+    public Object getBean() {
+        return bean;
+    }
+
+    public Method getMethod() {
+        return method;
+    }
+}

--- a/summer-beans/src/main/java/com/dianpoint/summer/web/servlet/RequestMappingHandlerAdapter.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/web/servlet/RequestMappingHandlerAdapter.java
@@ -1,0 +1,77 @@
+package com.dianpoint.summer.web.servlet;
+
+import com.dianpoint.summer.web.annotation.RequestParam;
+import com.dianpoint.summer.web.annotation.ResponseBody;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+
+public class RequestMappingHandlerAdapter implements HandlerAdapter {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public boolean supports(Object handler) {
+        return handler instanceof HandlerMethod;
+    }
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        HandlerMethod handlerMethod = (HandlerMethod) handler;
+        Method method = handlerMethod.getMethod();
+        Object bean = handlerMethod.getBean();
+
+        Object[] args = resolveArguments(request, response, method);
+        Object result = method.invoke(bean, args);
+
+        if (result == null) {
+            return;
+        }
+
+        ResponseBody responseBody = method.getAnnotation(ResponseBody.class);
+        if (responseBody != null || method.getDeclaringClass().getAnnotation(ResponseBody.class) != null) {
+            response.setContentType("application/json;charset=UTF-8");
+            response.getWriter().write(objectMapper.writeValueAsString(result));
+        } else if (result instanceof String) {
+            response.setContentType("text/plain;charset=UTF-8");
+            response.getWriter().write((String) result);
+        }
+    }
+
+    private Object[] resolveArguments(HttpServletRequest request, HttpServletResponse response, Method method) {
+        Parameter[] parameters = method.getParameters();
+        Object[] args = new Object[parameters.length];
+
+        for (int i = 0; i < parameters.length; i++) {
+            Class<?> type = parameters[i].getType();
+            if (type == HttpServletRequest.class) {
+                args[i] = request;
+            } else if (type == HttpServletResponse.class) {
+                args[i] = response;
+            } else {
+                RequestParam requestParam = parameters[i].getAnnotation(RequestParam.class);
+                if (requestParam != null) {
+                    String paramName = requestParam.value().isEmpty() ? requestParam.name() : requestParam.value();
+                    String paramValue = request.getParameter(paramName);
+                    if (paramValue == null && !requestParam.defaultValue().isEmpty()) {
+                        paramValue = requestParam.defaultValue();
+                    }
+                    args[i] = convertValue(paramValue, type);
+                }
+            }
+        }
+        return args;
+    }
+
+    private Object convertValue(String value, Class<?> type) {
+        if (value == null) return null;
+        if (type == String.class) return value;
+        if (type == int.class || type == Integer.class) return Integer.valueOf(value);
+        if (type == long.class || type == Long.class) return Long.valueOf(value);
+        if (type == boolean.class || type == Boolean.class) return Boolean.valueOf(value);
+        return value;
+    }
+}

--- a/summer-beans/src/main/java/com/dianpoint/summer/web/servlet/RequestMappingHandlerMapping.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/web/servlet/RequestMappingHandlerMapping.java
@@ -1,0 +1,43 @@
+package com.dianpoint.summer.web.servlet;
+
+import com.dianpoint.summer.beans.factory.support.DefaultListableBeanFactory;
+import com.dianpoint.summer.web.RequestMapping;
+
+import javax.servlet.http.HttpServletRequest;
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class RequestMappingHandlerMapping implements HandlerMapping {
+
+    private final Map<String, HandlerMethod> handlerMethods = new LinkedHashMap<>();
+
+    public RequestMappingHandlerMapping(DefaultListableBeanFactory beanFactory) {
+        for (String beanName : beanFactory.getBeanDefinitionNames()) {
+            try {
+                Class<?> clazz = Class.forName(beanFactory.getBeanDefinition(beanName).getClassName());
+                for (Method method : clazz.getDeclaredMethods()) {
+                    RequestMapping mapping = method.getAnnotation(RequestMapping.class);
+                    if (mapping != null) {
+                        String url = mapping.value();
+                        if (url.isEmpty()) {
+                            url = "/" + method.getName();
+                        }
+                        Object bean = beanFactory.getBean(beanName);
+                        handlerMethods.put(url, new HandlerMethod(bean, method));
+                    }
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    @Override
+    public HandlerMethod getHandler(HttpServletRequest request) throws Exception {
+        String uri = request.getRequestURI();
+        String contextPath = request.getContextPath();
+        String path = uri.substring(contextPath.length());
+        return handlerMethods.get(path);
+    }
+}

--- a/summer-beans/src/test/java/com/dianpoint/summer/test/web/HelloController.java
+++ b/summer-beans/src/test/java/com/dianpoint/summer/test/web/HelloController.java
@@ -1,0 +1,34 @@
+package com.dianpoint.summer.test.web;
+
+import com.dianpoint.summer.stereotype.Controller;
+import com.dianpoint.summer.web.RequestMapping;
+import com.dianpoint.summer.web.annotation.RequestParam;
+import com.dianpoint.summer.web.annotation.ResponseBody;
+
+@Controller
+public class HelloController {
+
+    @RequestMapping("/hello")
+    public String hello(@RequestParam("name") String name) {
+        return "Hello, " + name;
+    }
+
+    @RequestMapping("/json")
+    @ResponseBody
+    public User json(@RequestParam(value = "id", defaultValue = "0") int id) {
+        User user = new User();
+        user.setId(id);
+        user.setName("Test");
+        return user;
+    }
+
+    public static class User {
+        private int id;
+        private String name;
+
+        public int getId() { return id; }
+        public void setId(int id) { this.id = id; }
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+    }
+}

--- a/summer-beans/src/test/java/com/dianpoint/summer/test/web/MockHttpServletRequest.java
+++ b/summer-beans/src/test/java/com/dianpoint/summer/test/web/MockHttpServletRequest.java
@@ -1,0 +1,94 @@
+package com.dianpoint.summer.test.web;
+
+import javax.servlet.*;
+import javax.servlet.http.*;
+import java.io.*;
+import java.security.Principal;
+import java.util.*;
+
+public class MockHttpServletRequest implements HttpServletRequest {
+
+    private final String requestURI;
+    private final String method;
+    private final Map<String, String> parameters = new HashMap<>();
+
+    public MockHttpServletRequest(String requestURI, String method) {
+        this.requestURI = requestURI;
+        this.method = method;
+    }
+
+    public void setParameter(String name, String value) {
+        parameters.put(name, value);
+    }
+
+    @Override public String getRequestURI() { return requestURI; }
+    @Override public String getContextPath() { return ""; }
+    @Override public String getMethod() { return method; }
+    @Override public String getParameter(String name) { return parameters.get(name); }
+
+    @Override public String getAuthType() { return null; }
+    @Override public Cookie[] getCookies() { return new Cookie[0]; }
+    @Override public long getDateHeader(String name) { return 0; }
+    @Override public String getHeader(String name) { return null; }
+    @Override public Enumeration<String> getHeaders(String name) { return null; }
+    @Override public Enumeration<String> getHeaderNames() { return null; }
+    @Override public int getIntHeader(String name) { return 0; }
+    @Override public String getPathInfo() { return null; }
+    @Override public String getPathTranslated() { return null; }
+    @Override public String getQueryString() { return null; }
+    @Override public String getRemoteUser() { return null; }
+    @Override public boolean isUserInRole(String role) { return false; }
+    @Override public Principal getUserPrincipal() { return null; }
+    @Override public String getRequestedSessionId() { return null; }
+    @Override public StringBuffer getRequestURL() { return null; }
+    @Override public String getServletPath() { return null; }
+    @Override public HttpSession getSession(boolean create) { return null; }
+    @Override public HttpSession getSession() { return null; }
+    @Override public String changeSessionId() { return null; }
+    @Override public boolean isRequestedSessionIdValid() { return false; }
+    @Override public boolean isRequestedSessionIdFromCookie() { return false; }
+    @Override public boolean isRequestedSessionIdFromURL() { return false; }
+    @Override public boolean isRequestedSessionIdFromUrl() { return false; }
+    @Override public boolean authenticate(HttpServletResponse response) { return false; }
+    @Override public void login(String username, String password) {}
+    @Override public void logout() {}
+    @Override public Collection<Part> getParts() { return null; }
+    @Override public Part getPart(String name) { return null; }
+    @Override public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) { return null; }
+    @Override public Object getAttribute(String name) { return null; }
+    @Override public Enumeration<String> getAttributeNames() { return null; }
+    @Override public String getCharacterEncoding() { return null; }
+    @Override public void setCharacterEncoding(String env) {}
+    @Override public int getContentLength() { return 0; }
+    @Override public long getContentLengthLong() { return 0; }
+    @Override public String getContentType() { return null; }
+    @Override public ServletInputStream getInputStream() { return null; }
+    @Override public String getProtocol() { return null; }
+    @Override public String getScheme() { return null; }
+    @Override public String getServerName() { return null; }
+    @Override public int getServerPort() { return 0; }
+    @Override public BufferedReader getReader() { return null; }
+    @Override public String getRemoteAddr() { return null; }
+    @Override public String getRemoteHost() { return null; }
+    @Override public void setAttribute(String name, Object o) {}
+    @Override public void removeAttribute(String name) {}
+    @Override public Locale getLocale() { return null; }
+    @Override public Enumeration<Locale> getLocales() { return null; }
+    @Override public boolean isSecure() { return false; }
+    @Override public RequestDispatcher getRequestDispatcher(String path) { return null; }
+    @Override public String getRealPath(String path) { return null; }
+    @Override public int getRemotePort() { return 0; }
+    @Override public String getLocalName() { return null; }
+    @Override public String getLocalAddr() { return null; }
+    @Override public int getLocalPort() { return 0; }
+    @Override public ServletContext getServletContext() { return null; }
+    @Override public AsyncContext startAsync() throws IllegalStateException { return null; }
+    @Override public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) { return null; }
+    @Override public boolean isAsyncStarted() { return false; }
+    @Override public boolean isAsyncSupported() { return false; }
+    @Override public AsyncContext getAsyncContext() { return null; }
+    @Override public DispatcherType getDispatcherType() { return null; }
+    @Override public Map<String, String[]> getParameterMap() { return null; }
+    @Override public Enumeration<String> getParameterNames() { return null; }
+    @Override public String[] getParameterValues(String name) { return new String[0]; }
+}

--- a/summer-beans/src/test/java/com/dianpoint/summer/test/web/MockHttpServletResponse.java
+++ b/summer-beans/src/test/java/com/dianpoint/summer/test/web/MockHttpServletResponse.java
@@ -1,0 +1,60 @@
+package com.dianpoint.summer.test.web;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.Locale;
+
+public class MockHttpServletResponse implements HttpServletResponse {
+
+    private final ByteArrayOutputStream content = new ByteArrayOutputStream();
+    private final PrintWriter writer = new PrintWriter(content);
+    private String contentType;
+
+    @Override public void addCookie(Cookie cookie) {}
+    @Override public boolean containsHeader(String name) { return false; }
+    @Override public String encodeURL(String url) { return null; }
+    @Override public String encodeRedirectURL(String url) { return null; }
+    @Override public void sendError(int sc, String msg) {}
+    @Override public void sendError(int sc) {}
+    @Override public void sendRedirect(String location) {}
+    @Override public void setDateHeader(String name, long date) {}
+    @Override public void addDateHeader(String name, long date) {}
+    @Override public void setHeader(String name, String value) {}
+    @Override public void addHeader(String name, String value) {}
+    @Override public void setIntHeader(String name, int value) {}
+    @Override public void addIntHeader(String name, int value) {}
+    @Override public void setStatus(int sc) {}
+    @Override public void setStatus(int sc, String msg) {}
+    @Override public int getStatus() { return 0; }
+    @Override public String getHeader(String name) { return null; }
+    @Override public Collection<String> getHeaders(String name) { return null; }
+    @Override public Collection<String> getHeaderNames() { return null; }
+    @Override public String getCharacterEncoding() { return null; }
+    @Override public String getContentType() { return contentType; }
+    @Override public ServletOutputStream getOutputStream() { return null; }
+    @Override public PrintWriter getWriter() { return writer; }
+    @Override public void setCharacterEncoding(String charset) {}
+    @Override public void setContentLength(int len) {}
+    @Override public void setContentLengthLong(long len) {}
+    @Override public void setContentType(String type) { this.contentType = type; }
+    @Override public void setBufferSize(int size) {}
+    @Override public int getBufferSize() { return 0; }
+    @Override public void flushBuffer() { writer.flush(); }
+    @Override public void resetBuffer() {}
+    @Override public boolean isCommitted() { return false; }
+    @Override public void reset() {}
+    @Override public void setLocale(Locale loc) {}
+    @Override public Locale getLocale() { return null; }
+    @Override public String encodeUrl(String url) { return null; }
+    @Override public String encodeRedirectUrl(String url) { return null; }
+
+    public String getContentAsString() {
+        writer.flush();
+        return content.toString();
+    }
+}

--- a/summer-beans/src/test/java/com/dianpoint/summer/test/web/RequestMappingHandlerMappingTest.java
+++ b/summer-beans/src/test/java/com/dianpoint/summer/test/web/RequestMappingHandlerMappingTest.java
@@ -1,0 +1,103 @@
+package com.dianpoint.summer.test.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.dianpoint.summer.beans.BeansException;
+import com.dianpoint.summer.beans.factory.config.BeanDefinition;
+import com.dianpoint.summer.beans.factory.support.DefaultListableBeanFactory;
+import com.dianpoint.summer.web.servlet.HandlerMethod;
+import com.dianpoint.summer.web.servlet.RequestMappingHandlerAdapter;
+import com.dianpoint.summer.web.servlet.RequestMappingHandlerMapping;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.StringWriter;
+
+public class RequestMappingHandlerMappingTest {
+
+    private DefaultListableBeanFactory beanFactory;
+    private RequestMappingHandlerMapping handlerMapping;
+    private RequestMappingHandlerAdapter handlerAdapter;
+
+    @Before
+    public void setUp() {
+        beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerBeanDefinition("helloController",
+            new BeanDefinition("helloController", HelloController.class.getName()));
+
+        handlerMapping = new RequestMappingHandlerMapping(beanFactory);
+        handlerAdapter = new RequestMappingHandlerAdapter();
+    }
+
+    @Test
+    public void testHandlerMappingResolvesUrl() throws Exception {
+        HttpServletRequest request = new MockHttpServletRequest("/hello", "GET");
+        HandlerMethod handler = handlerMapping.getHandler(request);
+        assertThat(handler).isNotNull();
+        assertThat(handler.getBean()).isInstanceOf(HelloController.class);
+        assertThat(handler.getMethod().getName()).isEqualTo("hello");
+    }
+
+    @Test
+    public void testHandlerMappingReturnsNullForUnknownUrl() throws Exception {
+        HttpServletRequest request = new MockHttpServletRequest("/unknown", "GET");
+        HandlerMethod handler = handlerMapping.getHandler(request);
+        assertThat(handler).isNull();
+    }
+
+    @Test
+    public void testHandlerAdapterInvokesMethod() throws Exception {
+        helloControllerInit();
+
+        MockHttpServletRequest request = new MockHttpServletRequest("/hello", "GET");
+        request.setParameter("name", "World");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        HandlerMethod handler = handlerMapping.getHandler(request);
+        handlerAdapter.handle(request, response, handler);
+
+        assertThat(response.getContentAsString()).isEqualTo("Hello, World");
+    }
+
+    @Test
+    public void testHandlerAdapterReturnsJson() throws Exception {
+        helloControllerInit();
+
+        MockHttpServletRequest request = new MockHttpServletRequest("/json", "GET");
+        request.setParameter("id", "42");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        HandlerMethod handler = handlerMapping.getHandler(request);
+        handlerAdapter.handle(request, response, handler);
+
+        assertThat(response.getContentType()).isEqualTo("application/json;charset=UTF-8");
+        assertThat(response.getContentAsString()).contains("\"id\":42");
+        assertThat(response.getContentAsString()).contains("\"name\":\"Test\"");
+    }
+
+    @Test
+    public void testHandlerAdapterDefaultParameterValue() throws Exception {
+        helloControllerInit();
+
+        MockHttpServletRequest request = new MockHttpServletRequest("/json", "GET");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        HandlerMethod handler = handlerMapping.getHandler(request);
+        handlerAdapter.handle(request, response, handler);
+
+        assertThat(response.getContentAsString()).contains("\"id\":0");
+    }
+
+    @Test
+    public void testHandlerAdapterSupports() {
+        assertThat(handlerAdapter.supports(new HandlerMethod(new HelloController(),
+            HelloController.class.getDeclaredMethods()[0]))).isTrue();
+    }
+
+    private void helloControllerInit() throws BeansException {
+        beanFactory.getBean("helloController");
+    }
+}


### PR DESCRIPTION
## Summary

Implement a basic MVC web layer on top of the IoC container, replacing the empty DispatcherServlet stub with a functional HTTP request dispatcher.

### Changes
- **HandlerMapping**: Interface + RequestMappingHandlerMapping that scans @RequestMapping methods
- **HandlerAdapter**: Interface + RequestMappingHandlerAdapter with @RequestParam binding
- **DispatcherServlet**: doDispatch() flow (handler resolution → adapter selection → invocation)
- **@Controller**: Stereotype for web controllers
- **@RequestParam**: Parameter binding with default values
- **@ResponseBody**: JSON response serialization via Jackson

### Tests (6 tests)
- Handler mapping URL resolution and 404
- String response and @RequestParam binding
- JSON response with @ResponseBody
- Default parameter values

### Verification
mvn test -pl summer-beans  # 106 tests pass, 0 failures