### PR TITLE
feat: add @EventListener annotation for declarative event handling

### DIFF
--- a/summer-beans/src/main/java/com/dianpoint/summer/context/event/EventListener.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/context/event/EventListener.java
@@ -1,0 +1,11 @@
+package com.dianpoint.summer.context.event;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EventListener {
+}

--- a/summer-beans/src/main/java/com/dianpoint/summer/context/event/EventListenerMethodProcessor.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/context/event/EventListenerMethodProcessor.java
@@ -1,0 +1,67 @@
+package com.dianpoint.summer.context.event;
+
+import com.dianpoint.summer.beans.BeansException;
+import com.dianpoint.summer.beans.factory.BeanFactory;
+import com.dianpoint.summer.beans.factory.config.BeanPostProcessor;
+import com.dianpoint.summer.context.ApplicationEvent;
+import com.dianpoint.summer.context.ApplicationListener;
+import com.dianpoint.summer.context.SimpleApplicationEventPublisher;
+
+import java.lang.reflect.Method;
+
+public class EventListenerMethodProcessor implements BeanPostProcessor {
+
+    private BeanFactory beanFactory;
+    private final SimpleApplicationEventPublisher publisher = new SimpleApplicationEventPublisher();
+
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        return bean;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        Class<?> clazz = bean.getClass();
+        for (Method method : clazz.getDeclaredMethods()) {
+            EventListener annotation = method.getAnnotation(EventListener.class);
+            if (annotation != null) {
+                registerListener(bean, method);
+            }
+        }
+        return bean;
+    }
+
+    @Override
+    public void setBeanFactory(BeanFactory beanFactory) {
+        this.beanFactory = beanFactory;
+    }
+
+    public SimpleApplicationEventPublisher getPublisher() {
+        return publisher;
+    }
+
+    private void registerListener(Object bean, Method method) {
+        Class<?>[] paramTypes = method.getParameterTypes();
+        Class<?> eventType = paramTypes.length > 0 && ApplicationEvent.class.isAssignableFrom(paramTypes[0])
+            ? paramTypes[0] : ApplicationEvent.class;
+
+        ApplicationListener listener = new ApplicationListener() {
+            @Override
+            public void onApplicationEvent(ApplicationEvent event) {
+                if (eventType.isInstance(event)) {
+                    try {
+                        method.setAccessible(true);
+                        if (paramTypes.length == 1) {
+                            method.invoke(bean, event);
+                        } else {
+                            method.invoke(bean);
+                        }
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        };
+        publisher.addApplicationListener(listener);
+    }
+}

--- a/summer-beans/src/test/java/com/dianpoint/summer/test/event/EventListenerTest.java
+++ b/summer-beans/src/test/java/com/dianpoint/summer/test/event/EventListenerTest.java
@@ -1,0 +1,65 @@
+package com.dianpoint.summer.test.event;
+
+import com.dianpoint.summer.beans.BeansException;
+import com.dianpoint.summer.beans.factory.config.BeanDefinition;
+import com.dianpoint.summer.beans.factory.support.DefaultListableBeanFactory;
+import com.dianpoint.summer.context.ApplicationEvent;
+import com.dianpoint.summer.context.ContextRefreshEvent;
+import com.dianpoint.summer.context.event.EventListener;
+import com.dianpoint.summer.context.event.EventListenerMethodProcessor;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EventListenerTest {
+
+    private EventListenerMethodProcessor processor;
+    private DefaultListableBeanFactory factory;
+
+    public static class EventConsumer {
+        private final AtomicInteger count = new AtomicInteger(0);
+
+        @EventListener
+        public void onEvent(ApplicationEvent event) {
+            count.incrementAndGet();
+        }
+
+        public int getCount() {
+            return count.get();
+        }
+    }
+
+    @Before
+    public void setUp() {
+        processor = new EventListenerMethodProcessor();
+        factory = new DefaultListableBeanFactory();
+        factory.addBeanPostProcessor(processor);
+        factory.registerBeanDefinition("consumer",
+            new BeanDefinition("consumer", EventConsumer.class.getName()));
+    }
+
+    @Test
+    public void testEventListenerReceivesEvent() throws BeansException {
+        EventConsumer consumer = (EventConsumer) factory.getBean("consumer");
+        processor.getPublisher().publisher(new ApplicationEvent("test"));
+        assertThat(consumer.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void testEventListenerReceivesSubclassEvent() throws BeansException {
+        EventConsumer consumer = (EventConsumer) factory.getBean("consumer");
+        processor.getPublisher().publisher(new ContextRefreshEvent("refreshed"));
+        assertThat(consumer.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void testEventListenerMultipleEvents() throws BeansException {
+        EventConsumer consumer = (EventConsumer) factory.getBean("consumer");
+        processor.getPublisher().publisher(new ApplicationEvent("first"));
+        processor.getPublisher().publisher(new ApplicationEvent("second"));
+        assertThat(consumer.getCount()).isEqualTo(2);
+    }
+}


### PR DESCRIPTION
## Summary

Add @EventListener annotation support for declarative event handling.

### Changes
- **@EventListener**: Method-level annotation for event listener declaration
- **EventListenerMethodProcessor**: BeanPostProcessor that scans beans for @EventListener methods and auto-registers them
- Supports type-based event filtering by method parameter type

### Tests
EventListenerTest: 3 tests (receiving events, subclass events, multiple events)

### Verification
mvn test -pl summer-beans  # all tests pass