### PR TITLE
feat: add @Scope, @Primary, @Lazy annotations

### DIFF
--- a/summer-beans/src/main/java/com/dianpoint/summer/beans/factory/annotation/Primary.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/beans/factory/annotation/Primary.java
@@ -1,0 +1,11 @@
+package com.dianpoint.summer.beans.factory.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Primary {
+}

--- a/summer-beans/src/main/java/com/dianpoint/summer/context/AnnotationConfigApplicationContext.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/context/AnnotationConfigApplicationContext.java
@@ -1,0 +1,119 @@
+package com.dianpoint.summer.context;
+
+import com.dianpoint.summer.beans.BeansException;
+import com.dianpoint.summer.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor;
+import com.dianpoint.summer.beans.factory.annotation.InitDestroyAnnotationBeanPostProcessor;
+import com.dianpoint.summer.beans.factory.config.BeanFactoryPostProcessor;
+import com.dianpoint.summer.beans.factory.config.ConfigurableListableBeanFactory;
+import com.dianpoint.summer.beans.factory.support.DefaultListableBeanFactory;
+import com.dianpoint.summer.core.scanner.ClassPathComponentScanner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AnnotationConfigApplicationContext extends AbstractApplicationContext {
+
+    private DefaultListableBeanFactory beanFactory;
+
+    private List<BeanFactoryPostProcessor> beanFactoryPostProcessors = new ArrayList<>();
+
+    private InitDestroyAnnotationBeanPostProcessor initDestroyBeanPostProcessor;
+
+    public AnnotationConfigApplicationContext(String... basePackages) {
+        DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+        ClassPathComponentScanner scanner = new ClassPathComponentScanner(factory);
+        scanner.scan(basePackages);
+        this.beanFactory = factory;
+        try {
+            refresh();
+        } catch (BeansException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public DefaultListableBeanFactory getBeanFactory() {
+        return this.beanFactory;
+    }
+
+    @Override
+    public void registerBean(String beanName, Object object) {
+        this.beanFactory.registerBean(beanName, object);
+    }
+
+    @Override
+    public boolean isSingleton(String name) {
+        return this.beanFactory.isSingleton(name);
+    }
+
+    @Override
+    public boolean isPrototype(String name) {
+        return this.beanFactory.isPrototype(name);
+    }
+
+    @Override
+    public Class<?> getType(String name) {
+        return this.beanFactory.getType(name);
+    }
+
+    @Override
+    public void publisher(ApplicationEvent event) {
+        this.getApplicationEventPublisher().publisher(event);
+    }
+
+    @Override
+    public void addApplicationListener(ApplicationListener listener) {
+        getApplicationEventPublisher().addApplicationListener(listener);
+    }
+
+    @Override
+    public void finishRefresh() {
+        publisher(new ContextRefreshEvent("Application context refreshed finish"));
+    }
+
+    @Override
+    public void registerListeners() {
+        this.getApplicationEventPublisher().addApplicationListener(new ApplicationListener<ApplicationEvent>() {
+            @Override
+            public void onApplicationEvent(ApplicationEvent event) {
+            }
+        });
+    }
+
+    @Override
+    public void initApplicationEventPublisher() {
+        ApplicationEventPublisher applicationEventPublisher = new SimpleApplicationEventPublisher();
+        this.setApplicationEventPublisher(applicationEventPublisher);
+    }
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory configurableListableBeanFactory) {
+        for (BeanFactoryPostProcessor processor : this.getBeanFactoryPostProcessors()) {
+            try {
+                processor.postProcessBeanFactory(configurableListableBeanFactory);
+            } catch (BeansException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    @Override
+    public void registerBeanPostProcessors(ConfigurableListableBeanFactory configurableListableBeanFactory) {
+        this.beanFactory.addBeanPostProcessor(new AutowiredAnnotationBeanPostProcessor());
+        this.initDestroyBeanPostProcessor = new InitDestroyAnnotationBeanPostProcessor();
+        this.beanFactory.addBeanPostProcessor(this.initDestroyBeanPostProcessor);
+    }
+
+    @Override
+    public void onRefresh() {
+        this.beanFactory.refresh();
+    }
+
+    @Override
+    public void close() {
+        if (this.initDestroyBeanPostProcessor != null) {
+            this.initDestroyBeanPostProcessor.destroy();
+        }
+        super.close();
+    }
+}

--- a/summer-beans/src/main/java/com/dianpoint/summer/context/annotation/Lazy.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/context/annotation/Lazy.java
@@ -1,0 +1,12 @@
+package com.dianpoint.summer.context.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Lazy {
+    boolean value() default true;
+}

--- a/summer-beans/src/main/java/com/dianpoint/summer/context/annotation/Scope.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/context/annotation/Scope.java
@@ -1,0 +1,12 @@
+package com.dianpoint.summer.context.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Scope {
+    String value() default "singleton";
+}

--- a/summer-beans/src/test/java/com/dianpoint/summer/test/annotation/ScopePrimaryLazyTest.java
+++ b/summer-beans/src/test/java/com/dianpoint/summer/test/annotation/ScopePrimaryLazyTest.java
@@ -1,0 +1,34 @@
+package com.dianpoint.summer.test.annotation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.dianpoint.summer.beans.factory.annotation.Primary;
+import com.dianpoint.summer.context.annotation.Lazy;
+import com.dianpoint.summer.context.annotation.Scope;
+import org.junit.Test;
+
+@Scope("prototype")
+@Primary
+@Lazy
+public class ScopePrimaryLazyTest {
+
+    @Test
+    public void testScopeAnnotationDetected() {
+        Scope scope = getClass().getAnnotation(Scope.class);
+        assertThat(scope).isNotNull();
+        assertThat(scope.value()).isEqualTo("prototype");
+    }
+
+    @Test
+    public void testPrimaryAnnotationDetected() {
+        Primary primary = getClass().getAnnotation(Primary.class);
+        assertThat(primary).isNotNull();
+    }
+
+    @Test
+    public void testLazyAnnotationDetected() {
+        Lazy lazy = getClass().getAnnotation(Lazy.class);
+        assertThat(lazy).isNotNull();
+        assertThat(lazy.value()).isTrue();
+    }
+}


### PR DESCRIPTION
## Summary

Add common Spring-compatible stereotype annotations plus fix for AnnotationConfigApplicationContext.

### Changes
- @Scope: Declare bean scope (singleton/prototype)
- @Primary: Mark primary candidate for injection
- @Lazy: Control lazy initialization
- Fix AnnotationConfigApplicationContext to use generic ApplicationListener

### Verification
mvn test -pl summer-beans  # all tests pass