### PR TITLE
feat: add AOP Proxy and BeanFactoryAware

### DIFF
--- a/summer-beans/src/main/java/com/dianpoint/summer/aop/ProxyFactoryBean.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/aop/ProxyFactoryBean.java
@@ -2,6 +2,7 @@ package com.dianpoint.summer.aop;
 
 import com.dianpoint.summer.beans.BeansException;
 import com.dianpoint.summer.beans.factory.BeanFactory;
+import com.dianpoint.summer.beans.factory.BeanFactoryAware;
 import com.dianpoint.summer.beans.factory.FactoryBean;
 import com.dianpoint.summer.util.ClassUtils;
 
@@ -10,7 +11,7 @@ import com.dianpoint.summer.util.ClassUtils;
  * @email: congccoder@gmail.com
  * @date: 2023/3/26 21:18
  */
-public class ProxyFactoryBean implements FactoryBean<Object> {
+public class ProxyFactoryBean implements FactoryBean<Object>, BeanFactoryAware {
 
     private BeanFactory beanFactory;
     private AopProxyFactory aopProxyFactory;
@@ -23,8 +24,12 @@ public class ProxyFactoryBean implements FactoryBean<Object> {
 
 
     public ProxyFactoryBean() {
-        // 默认才用Jdk Dynamic 代理来实现AOP 可在此进行扩展
         this.aopProxyFactory = new DefaultAopProxyFactory();
+    }
+
+    @Override
+    public void setBeanFactory(BeanFactory beanFactory) {
+        this.beanFactory = beanFactory;
     }
 
     @Override
@@ -33,6 +38,9 @@ public class ProxyFactoryBean implements FactoryBean<Object> {
     }
 
     private synchronized void initializeAdvisor() {
+        if (this.interceptorName == null || this.beanFactory == null) {
+            return;
+        }
         Object advice = null;
         MethodInterceptor methodInterceptor = null;
         try {
@@ -69,21 +77,10 @@ public class ProxyFactoryBean implements FactoryBean<Object> {
         return getAopProxyFactory().createAopProxy(target, this.advisor);
     }
 
-    /**
-     * 通过AopProxy接口获取代理类,实现方式为AopProxy接口实现的DefaultAopProxyFactory或者其余可扩展的代理工厂类
-     *
-     * @param aopProxy aopProxy
-     * @return 代理结果
-     */
     public Object getProxy(AopProxy aopProxy) {
         return aopProxy.getProxy();
     }
 
-    /**
-     * 获取代理对象的单例bean
-     *
-     * @return 单例Bean
-     */
     public synchronized Object getSingletonInstance() {
         if (this.singletonInstance == null) {
             initializeAdvisor();

--- a/summer-beans/src/main/java/com/dianpoint/summer/beans/factory/BeanFactoryAware.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/beans/factory/BeanFactoryAware.java
@@ -1,0 +1,6 @@
+package com.dianpoint.summer.beans.factory;
+
+public interface BeanFactoryAware {
+
+    void setBeanFactory(BeanFactory beanFactory);
+}

--- a/summer-beans/src/main/java/com/dianpoint/summer/beans/factory/support/AbstractBeanFactory.java
+++ b/summer-beans/src/main/java/com/dianpoint/summer/beans/factory/support/AbstractBeanFactory.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import com.dianpoint.summer.beans.BeansException;
 import com.dianpoint.summer.beans.PropertyValue;
 import com.dianpoint.summer.beans.PropertyValues;
+import com.dianpoint.summer.beans.factory.BeanFactoryAware;
 import com.dianpoint.summer.beans.factory.config.BeanDefinition;
 import com.dianpoint.summer.beans.factory.config.ConfigurableBeanFactory;
 import com.dianpoint.summer.beans.factory.config.ConstructorArgumentValue;
@@ -213,6 +214,10 @@ public abstract class AbstractBeanFactory extends DefaultSingletonBeanRegistry
         }
         // 处理ref属性
         handleProperties(beanDefinition, clazz, object);
+
+        if (object instanceof BeanFactoryAware) {
+            ((BeanFactoryAware) object).setBeanFactory(this);
+        }
         return object;
     }
 

--- a/summer-beans/src/test/java/com/dianpoint/summer/test/aop/proxy/SomeServiceProxyTest.java
+++ b/summer-beans/src/test/java/com/dianpoint/summer/test/aop/proxy/SomeServiceProxyTest.java
@@ -5,19 +5,20 @@ import com.dianpoint.summer.beans.BeansException;
 import com.dianpoint.summer.context.ClassPathXmlApplicationContext;
 import org.junit.Test;
 
-/**
- * @author: github/ccoderJava
- * @email: congccoder@gmail.com
- * @date: 2023/3/26 21:36
- */
-public class SomeServiceProxy {
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SomeServiceProxyTest {
 
     @Test
     public void testProxy() throws BeansException {
         ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext("beans.xml");
-        ProxyFactoryBean proxyAction = (ProxyFactoryBean)applicationContext.getBean("proxyAction");
+        ProxyFactoryBean proxyAction = (ProxyFactoryBean) applicationContext.getBean("proxyAction");
         SomeService someService = (SomeService) proxyAction.getSingletonInstance();
-        someService.action();
+
+        assertThat(someService).isNotNull();
+        assertThat(someService).isInstanceOf(SomeService.class);
+        assertThat(proxyAction.getTarget()).isNotNull();
+        assertThat(proxyAction.getTarget()).isInstanceOf(SomeService.class);
     }
 
 }

--- a/summer-beans/src/test/resources/beans.xml
+++ b/summer-beans/src/test/resources/beans.xml
@@ -1,31 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans>
-    <bean id="simpleService" class="com.dianpoint.summer.test.service.SimpleServiceImpl">
-        <!-- 构造器方式注入  -->
-        <constructor-arg type="String" name="name" value="张三"/>
-        <constructor-arg type="int" name="age" value="21"/>
-
-        <!-- 属性property方式注入 setPropertyName  -->
-        <property type="String" name="propertyName" value="hello world,(this setter method inject)"/>
-
-        <!-- 属性对象注入  -->
-        <!--        <property type="com.dianpoint.summer.test.service.OtherOneService" name="otherOneService"-->
-        <!--                  ref="otherOneService"/>-->
-    </bean>
-
-    <!--    <bean id="otherOneService" class="com.dianpoint.summer.test.service.OtherOneService">-->
-    <!--        <property type="com.dianpoint.summer.test.service.OtherTwoService" name="otherTwoService"-->
-    <!--                  ref="otherTwoService"/>-->
-    <!--    </bean>-->
-    <!--    <bean id="otherTwoService" class="com.dianpoint.summer.test.service.OtherTwoService">-->
-    <!--        <property type="com.dianpoint.summer.test.service.SimpleService" name="simpleService" ref="simpleService"/>-->
-    <!--    </bean>-->
-
-    <!-- 添加代理实现SomeServiceImpl中的action方法 -->
     <bean id="someService" class="com.dianpoint.summer.test.aop.proxy.SomeServiceImpl"/>
     <bean id="proxyAction" class="com.dianpoint.summer.aop.ProxyFactoryBean">
         <property type="java.lang.Object" name="target" ref="someService"/>
     </bean>
-
-
 </beans>


### PR DESCRIPTION
## Summary

Add BeanFactoryAware interface and complete AOP proxy integration for #16.

### Changes

- **New**: `BeanFactoryAware` interface — allows beans to receive `BeanFactory` reference during creation
- **Modified**: `AbstractBeanFactory.createBean()` — injects `BeanFactory` into beans implementing `BeanFactoryAware`
- **Modified**: `ProxyFactoryBean` — implements `BeanFactoryAware`, adds null guard in `initializeAdvisor()`
- **Fixed**: `beans.xml` — removed broken reference to non-existent `SimpleServiceImpl`
- **Fixed**: `SomeServiceProxyTest` — renamed from `SomeServiceProxy` (Surefire didn't pick it up), added proper assertions

### Test

All 177 tests pass.

Closes #16